### PR TITLE
Two NULs copied to dst when copying "" using utf8cpy

### DIFF
--- a/utf8.h
+++ b/utf8.h
@@ -240,9 +240,9 @@ void* utf8cpy(void* dst, const void* src) {
 
   // overwriting anything previously in dst, write byte-by-byte
   // from src
-  do {
+  while ('\0' != *s) {
     *d++ = *s++;
-  } while ('\0' != *s);
+  }
 
   // append null terminating byte
   *d = '\0';


### PR DESCRIPTION
If the `src` argument to `utf8cpy` is `""`, the empty string, `'\0'` is assigned twice to `dst`, once in the loop and the second time after it.

I believe this is not the intended behavior of this function.