### PR TITLE
Fix undefined behavior on empty string in utf8cat

### DIFF
--- a/utf8.h
+++ b/utf8.h
@@ -162,9 +162,9 @@ void* utf8cat(void* dst, const void* src) {
   }
 
   // overwriting the null terminating byte in dst, append src byte-by-byte
-  do {
+  while ('\0' != *s) {
     *d++ = *s++;
-  } while ('\0' != *s);
+  }
 
   // write out a new null terminating byte into dst
   *d = '\0';


### PR DESCRIPTION
When src argument to utf8cat is an empty string, memory is accessed
outside of its bounds.

Similar bug as the previous.