### PR TITLE
First version of utf8ncasecmp

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ strxfrm | utf8xfrm |
 strings.h | utf8.h | complete
 ---------|--------|---------
 strcasecmp | utf8casecmp | ~~&#10004;~~
-strncasecmp | utf8ncasecmp |
+strncasecmp | utf8ncasecmp | ~~&#10004;~~
 
 ## Usage ##
 
@@ -62,7 +62,7 @@ Anywhere in the string.h documentation where it refers to 'bytes' I have changed
 - Investigate adding dst buffer sizes for utf8cpy and utf8cat to catch overwrites (as suggested by [@FlohOfWoe](https://twitter.com/FlohOfWoe) in https://twitter.com/FlohOfWoe/status/618669237771608064)
 - Investigate adding a utf8canon which would turn 'bad' utf8 sequences (like ASCII values encoded in 4-byte utf8 codepoints) into their 'good' equivalents (as suggested by [@KmBenzie](https://twitter.com/KmBenzie))
 - Investigate changing to [Creative Commons Zero License](http://creativecommons.org/publicdomain/zero/1.0/legalcode.txt) (as suggested by [@mcclure111](https://twitter.com/mcclure111))
-- Add ~~utf8casecmp and~~ utf8ncasecmp to compare two strings case-insensitively (as insensitively suggested by [@daniel_collin](https://twitter.com/daniel_collin))
+- ~~Add utf8casecmp and utf8ncasecmp to compare two strings case-insensitively (as insensitively suggested by [@daniel_collin](https://twitter.com/daniel_collin))~~
 - Extend utf8casecmp range to consume non-ASCII case differences too (I don't even rightly know if there are any!)
 
 ## License ##

--- a/test/main.c
+++ b/test/main.c
@@ -134,7 +134,7 @@ const char data[] = {
 };
 
 const char cmp[] = { '\xce', '\xbc', '\xcf', '\x85', '\0' };
-  
+
 const char lt[] = {
   '\xce',
   '\x93',
@@ -574,6 +574,30 @@ int main(const int argc, const char* const argv[]) {
 
   if (0 != utf8casecmp(allascii1, allascii2)) {
     return 69;
+  }
+
+  if (0 >= utf8ncasecmp(data, lt, 4000)) {
+    return 70;
+  }
+
+  if (0 != utf8ncasecmp(data, lt, 7)) {
+    return 71;
+  }
+
+  if (0 != utf8ncasecmp(data, data, 4000)) {
+    return 72;
+  }
+
+  if (0 != utf8ncasecmp(data, data, 7)) {
+    return 73;
+  }
+
+  if (0 <= utf8ncasecmp(data, gt, 4000)) {
+    return 74;
+  }
+
+  if (0 != utf8ncasecmp(data, gt, 7)) {
+    return 75;
   }
 
 

--- a/utf8.h
+++ b/utf8.h
@@ -78,6 +78,13 @@ utf8_weak void* utf8dup(const void* src);
 // excluding the null terminating byte.
 utf8_pure utf8_weak size_t utf8len(const void* str);
 
+// While ignoring the case of ASCII characters, return less
+// than 0, 0, greater than 0 if src1 < src2, src1 == src2,
+// src1 > src2 respectively. Checking at most n
+// bytes of each utf8 string.
+utf8_pure utf8_weak int utf8ncasecmp(const void* src1, const void* src2,
+                                     size_t n);
+
 // Append the utf8 string src onto the utf8 string dst,
 // writing at most n+1 bytes. Can produce an invalid utf8
 // string if n falls partway through a utf8 codepoint.
@@ -352,6 +359,36 @@ size_t utf8len(const void* str) {
   }
 
   return length;
+}
+
+int utf8ncasecmp(const void* src1, const void* src2, size_t n) {
+  const unsigned char* s1 = (const unsigned char* )src1;
+  const unsigned char* s2 = (const unsigned char* )src2;
+
+  while ((('\0' != *s1) || ('\0' != *s2)) && (0 != n--)) {
+    unsigned char a = *s1;
+    unsigned char b = *s2;
+
+    if (('A' <= a) && ('Z' >= a)) {
+      a |= 0x20; // make a lowercase
+    }
+
+    if (('A' <= b) && ('Z' >= b)) {
+      b |= 0x20; // make b lowercase
+    }
+
+    if (a < b) {
+      return -1;
+    } else if (a > b) {
+      return 1;
+    }
+
+    s1++;
+    s2++;
+    }
+
+    // both utf8 strings matched
+    return 0;
 }
 
 void* utf8ncat(void* dst, const void* src, size_t n) {
@@ -706,6 +743,7 @@ void* utf8valid(const void* str) {
 
   return 0;
 }
+
 
 #ifdef __cplusplus
 } // extern "C"


### PR DESCRIPTION
 - *utf8ncasecmp* only ignores cases of ASCII values.
 - I also added new test cases in *test/main.c*.
 - Tested with GCC 4.6.3 and clang 3.4. Not tested with MSVC.