### PR TITLE
Add utf8codepoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A simple one header solution to supporting utf8 strings in C and C++.
 
-Functions are provided to match the string.h header but with a utf8* prefix instead of the str* prefix from string.h.
+Functions provided from the C header string.h but with a utf8* prefix instead of the str* prefix:
 
 string.h | utf8.h | complete
 ---------|--------|---------
@@ -25,18 +25,26 @@ strncpy | utf8ncpy | &#10004;
 strpbrk | utf8pbrk | &#10004;
 strrchr | utf8rchr | &#10004;
 strsep | utf8sep |
- | utf8size | &#10004;
 strspn | utf8spn | &#10004;
 strstr | utf8str | &#10004;
 strtok | utf8tok |
- | utf8valid | &#10004;
 strxfrm | utf8xfrm |
 
+Functions provided from the C header strings.h but with a utf8* prefix instead of the str* prefix:
+
 strings.h | utf8.h | complete
----------|--------|---------
+----------|--------|---------
 strcasecmp | utf8casecmp | ~~&#10004;~~
 strncasecmp | utf8ncasecmp | ~~&#10004;~~
 strcasestr | utf8casestr | ~~&#10004;~~
+
+Functions provided that are unique to utf8.h:
+
+utf8.h | complete
+-------|---------
+utf8codepoint | &#10004;
+utf8size | &#10004;
+utf8valid | &#10004;
 
 ## Usage ##
 
@@ -52,7 +60,7 @@ The utf8.h API matches the string.h API as much as possible by design. There are
 
 I use void* instead of char* when passing around utf8 strings. My reasoning is that I really don't want people accidentally thinking they can use integer arthimetic on the pointer and always get a valid character like you would with an ASCII string. Having it as a void* forces a user to explicitly cast the utf8 string to char* such that the onus is on them not to break the code anymore!
 
-Anywhere in the string.h documentation where it refers to 'bytes' I have changed that to utf8 codepoints. For instance, utf8len will return the number of utf8 codepoints in a utf8 string - which does not necessarily equate to the number of bytes.
+Anywhere in the string.h or strings.h documentation where it refers to 'bytes' I have changed that to utf8 codepoints. For instance, utf8len will return the number of utf8 codepoints in a utf8 string - which does not necessarily equate to the number of bytes.
 
 ## Todo ##
 

--- a/test/main.c
+++ b/test/main.c
@@ -132,7 +132,7 @@ UTEST(utf8cat, cat_data_data) {
 
 UTEST(utf8str, cmp) { ASSERT_EQ(data + 21, utf8str(data, cmp)); }
 
-UTEST(utf8str, test) { ASSERT_EQ((void*)0, utf8str(data, "test")); }
+UTEST(utf8str, test) { ASSERT_EQ((void *)0, utf8str(data, "test")); }
 
 UTEST(utf8str, empty) { ASSERT_EQ(data, utf8str(data, "")); }
 
@@ -432,5 +432,15 @@ UTEST(utf8ncasecmp, eq_small) { ASSERT_EQ(0, utf8ncasecmp(data, data, 7)); }
 UTEST(utf8ncasecmp, gt_large) { ASSERT_GT(0, utf8ncasecmp(data, gt, 4000)); }
 
 UTEST(utf8ncasecmp, gt_small) { ASSERT_EQ(0, utf8ncasecmp(data, gt, 7)); }
+
+UTEST(utf8codepoint, data) {
+  long codepoint;
+  unsigned expected_length = utf8len(data) - 1;
+  for (void *v = utf8codepoint(data, &codepoint); '\0' != codepoint;
+       v = utf8codepoint(v, &codepoint)) {
+    ASSERT_EQ(expected_length, utf8len(v));
+    expected_length -= 1;
+  }
+}
 
 UTEST_MAIN();

--- a/test/main.c
+++ b/test/main.c
@@ -435,8 +435,9 @@ UTEST(utf8ncasecmp, gt_small) { ASSERT_EQ(0, utf8ncasecmp(data, gt, 7)); }
 
 UTEST(utf8codepoint, data) {
   long codepoint;
+  void *v;
   unsigned expected_length = utf8len(data) - 1;
-  for (void *v = utf8codepoint(data, &codepoint); '\0' != codepoint;
+  for (v = utf8codepoint(data, &codepoint); '\0' != codepoint;
        v = utf8codepoint(v, &codepoint)) {
     ASSERT_EQ(expected_length, utf8len(v));
     expected_length -= 1;

--- a/utf8.h
+++ b/utf8.h
@@ -131,6 +131,10 @@ utf8_pure utf8_weak void *utf8casestr(const void *haystack, const void *needle);
 // utf8 codepoint on failure.
 utf8_pure utf8_weak void *utf8valid(const void *str);
 
+// Sets out_codepoint to the next utf8 codepoint in str, and returns the address
+// of the utf8 codepoint after the current one in str.
+utf8_weak void *utf8codepoint(const void *str, long *out_codepoint);
+
 #undef utf8_weak
 #undef utf8_pure
 
@@ -798,6 +802,32 @@ void *utf8valid(const void *str) {
   }
 
   return 0;
+}
+
+void *utf8codepoint(const void *str, long *out_codepoint) {
+  const char *s = (const char *)str;
+
+  if (0xf0 == (0xf8 & s[0])) {
+    // 4 byte utf8 codepoint
+    *out_codepoint = ((0x07 & s[0]) << 18) | ((0x3f & s[1]) << 12) |
+                     ((0x3f & s[2]) << 6) | (0x3f & s[3]);
+    s += 4;
+  } else if (0xe0 == (0xf0 & s[0])) {
+    // 3 byte utf8 codepoint
+    *out_codepoint =
+        ((0x0f & s[0]) << 12) | ((0x3f & s[1]) << 6) | (0x3f & s[2]);
+    s += 3;
+  } else if (0xc0 == (0xe0 & s[0])) {
+    // 2 byte utf8 codepoint
+    *out_codepoint = ((0x1f & s[0]) << 6) | (0x3f & s[1]);
+    s += 2;
+  } else {
+    // 1 byte utf8 codepoint otherwise
+    *out_codepoint = s[0];
+    s += 1;
+  }
+
+  return (void *)s;
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
utf8codepoint allows user to much more easily iterate through a utf8 string.

For example:

```
void *data = ...; // some utf8 string
  long codepoint;
  unsigned expected_length = utf8len(data) - 1;
  for (void *v = utf8codepoint(data, &codepoint); '\0' != codepoint;
       v = utf8codepoint(v, &codepoint)) {
    // use codepoint as your utf8 codepoint!
    // expected_length is equal to utf8len(v);
    expected_length -= 1;
  }
```