### PR TITLE
Fix function name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ utf8codepoint | &#10004;
 utf8size | &#10004;
 utf8valid | &#10004;
 utf8codepointsize | &#10004;
-utf8addcodepoint | &#10004;
+utf8catcodepoint | &#10004;
 
 ## Usage ##
 


### PR DESCRIPTION
It said `utf8addcodepoint` while we renamed it :)