### PR TITLE
Added utf8islower, utf8isupper, utf8lwr, utf8upr

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,10 @@ utf8size | &#10004;
 utf8valid | &#10004;
 utf8codepointsize | &#10004;
 utf8catcodepoint | &#10004;
-utf8lwr | ~~&#10004;~~
-utf8upr | ~~&#10004;~~
+utf8isupper | 
+utf8islower | 
+utf8lwr | 
+utf8upr | 
 
 ## Usage ##
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ utf8size | &#10004;
 utf8valid | &#10004;
 utf8codepointsize | &#10004;
 utf8catcodepoint | &#10004;
+utf8lwr | ~~&#10004;~~
+utf8upr | ~~&#10004;~~
 
 ## Usage ##
 

--- a/test/main.c
+++ b/test/main.c
@@ -450,7 +450,7 @@ UTEST(utf8codepointsize, size_4) { ASSERT_EQ(4, utf8codepointsize(0x20C78)); }
 
 UTEST(utf8catcodepoint, data) {
   char buffer[129];
-  char* p = buffer;
+  char *p = buffer;
   long cp;
   int i;
   memset(buffer, 0, 129);
@@ -462,6 +462,28 @@ UTEST(utf8catcodepoint, data) {
     }
   }
   ASSERT_EQ(51, utf8len(buffer));
+}
+
+UTEST(utf8lwr, ascii) {
+  size_t sz;
+  char *str;
+  sz = strlen(ascii1);
+  str = (char *)malloc(sz + 1);
+  memcpy(str, ascii1, sz + 1);
+  utf8lwr(str);
+  ASSERT_EQ(0, strcmp(str, "i like goats yarhar."));
+  free(str);
+}
+
+UTEST(utf8upr, ascii) {
+  size_t sz;
+  char *str;
+  sz = strlen(ascii1);
+  str = (char *)malloc(sz + 1);
+  memcpy(str, ascii1, sz + 1);
+  utf8upr(str);
+  ASSERT_EQ(0, strcmp(str, "I LIKE GOATS YARHAR."));
+  free(str);
 }
 
 UTEST_MAIN();

--- a/test/main.c
+++ b/test/main.c
@@ -464,6 +464,11 @@ UTEST(utf8catcodepoint, data) {
   ASSERT_EQ(51, utf8len(buffer));
 }
 
+UTEST(utf8islower, upper) { ASSERT_EQ(0, utf8islower('P')); }
+UTEST(utf8islower, lower) { ASSERT_EQ(1, utf8islower('p')); }
+UTEST(utf8isupper, upper) { ASSERT_EQ(1, utf8isupper('P')); }
+UTEST(utf8isupper, lower) { ASSERT_EQ(0, utf8isupper('p')); }
+
 UTEST(utf8lwr, ascii) {
   size_t sz;
   char *str;

--- a/utf8.h
+++ b/utf8.h
@@ -150,7 +150,7 @@ utf8_nonnull utf8_pure utf8_weak void *utf8valid(const void *str);
 // Sets out_codepoint to the next utf8 codepoint in str, and returns the address
 // of the utf8 codepoint after the current one in str.
 utf8_nonnull utf8_weak void *utf8codepoint(const void *utf8_restrict str,
-                                           long *utf8_restrict out_codepoint);
+                                           int *utf8_restrict out_codepoint);
 
 // Returns the size of the given codepoint in bytes.
 utf8_weak size_t utf8codepointsize(int chr);
@@ -845,7 +845,7 @@ void *utf8valid(const void *str) {
 }
 
 void *utf8codepoint(const void *utf8_restrict str,
-                    long *utf8_restrict out_codepoint) {
+                    int *utf8_restrict out_codepoint) {
   const char *s = (const char *)str;
 
   if (0xf0 == (0xf8 & s[0])) {
@@ -949,7 +949,7 @@ int utf8isupper(int chr)
 void utf8lwr(void *utf8_restrict str)
 {
   void *p, *pn;
-  long cp;
+  int cp;
 
   p = (char *)str;
   pn = utf8codepoint(p, &cp);
@@ -967,7 +967,7 @@ void utf8lwr(void *utf8_restrict str)
 void utf8upr(void *utf8_restrict str)
 {
   void *p, *pn;
-  long cp;
+  int cp;
 
   p = (char *)str;
   pn = utf8codepoint(p, &cp);

--- a/utf8.h
+++ b/utf8.h
@@ -160,6 +160,9 @@ utf8_weak size_t utf8codepointsize(int chr);
 // is not enough space for the codepoint, this function returns null.
 utf8_nonnull utf8_weak void *utf8catcodepoint(void *utf8_restrict str, int chr, size_t n);
 
+utf8_weak int utf8islower(int chr);
+utf8_weak int utf8isupper(int chr);
+
 utf8_nonnull utf8_weak void utf8lwr(void *utf8_restrict str);
 utf8_nonnull utf8_weak void utf8upr(void *utf8_restrict str);
 
@@ -918,6 +921,22 @@ void *utf8catcodepoint(void *utf8_restrict str, int chr, size_t n) {
   }
 
   return s;
+}
+
+int utf8islower(int chr)
+{
+  if (('a' <= chr) && ('z' >= chr)) {
+    return 1;
+  }
+  return 0;
+}
+
+int utf8isupper(int chr)
+{
+  if (('A' <= chr) && ('Z' >= chr)) {
+    return 1;
+  }
+  return 0;
 }
 
 void utf8lwr(void *utf8_restrict str)

--- a/utf8.h
+++ b/utf8.h
@@ -160,10 +160,16 @@ utf8_weak size_t utf8codepointsize(int chr);
 // is not enough space for the codepoint, this function returns null.
 utf8_nonnull utf8_weak void *utf8catcodepoint(void *utf8_restrict str, int chr, size_t n);
 
+// Returns 1 if the given character is lowercase, or 0 if it is not.
 utf8_weak int utf8islower(int chr);
+
+// Returns 1 if the given character is uppercase, or 0 if it is not.
 utf8_weak int utf8isupper(int chr);
 
+// Transform the given string into all lowercase codepoints.
 utf8_nonnull utf8_weak void utf8lwr(void *utf8_restrict str);
+
+// Transform the given string into all uppercase codepoints.
 utf8_nonnull utf8_weak void utf8upr(void *utf8_restrict str);
 
 #undef utf8_weak
@@ -925,10 +931,11 @@ void *utf8catcodepoint(void *utf8_restrict str, int chr, size_t n) {
 
 int utf8islower(int chr)
 {
-  if (('a' <= chr) && ('z' >= chr)) {
-    return 1;
+  if (('A' <= chr) && ('Z' >= chr)) {
+    return 0;
   }
-  return 0;
+  // Because we're not all-inclusive, assume everything else is lowercase
+  return 1;
 }
 
 int utf8isupper(int chr)

--- a/utf8.h
+++ b/utf8.h
@@ -160,6 +160,9 @@ utf8_weak size_t utf8codepointsize(int chr);
 // is not enough space for the codepoint, this function returns null.
 utf8_nonnull utf8_weak void *utf8catcodepoint(void *utf8_restrict str, int chr, size_t n);
 
+utf8_nonnull utf8_weak void utf8lwr(void *utf8_restrict str);
+utf8_nonnull utf8_weak void utf8upr(void *utf8_restrict str);
+
 #undef utf8_weak
 #undef utf8_pure
 #undef utf8_nonnull
@@ -915,6 +918,42 @@ void *utf8catcodepoint(void *utf8_restrict str, int chr, size_t n) {
   }
 
   return s;
+}
+
+void utf8lwr(void *utf8_restrict str)
+{
+  void *p, *pn;
+  long cp;
+
+  p = (char *)str;
+  pn = utf8codepoint(p, &cp);
+
+  while (cp != 0) {
+    if (('A' <= cp) && ('Z' >= cp)) {
+      cp |= 0x20;
+      utf8catcodepoint(p, cp, 1);
+    }
+    p = pn;
+    pn = utf8codepoint(p, &cp);
+  }
+}
+
+void utf8upr(void *utf8_restrict str)
+{
+  void *p, *pn;
+  long cp;
+
+  p = (char *)str;
+  pn = utf8codepoint(p, &cp);
+
+  while (cp != 0) {
+    if (('a' <= cp) && ('z' >= cp)) {
+      cp &= ~0x20;
+      utf8catcodepoint(p, cp, 1);
+    }
+    p = pn;
+    pn = utf8codepoint(p, &cp);
+  }
 }
 
 #undef utf8_restrict

--- a/utf8.h
+++ b/utf8.h
@@ -29,6 +29,13 @@
 #include <stddef.h>
 #include <stdlib.h>
 
+#if defined(_MSC_VER)
+#define int32_t __int32
+#define uint32_t __uint32
+#else
+#include <stdint.h>
+#endif
+
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wold-style-cast"
@@ -64,7 +71,7 @@ utf8_nonnull utf8_weak void *utf8cat(void *utf8_restrict dst,
                                      const void *utf8_restrict src);
 
 // Find the first match of the utf8 codepoint chr in the utf8 string src.
-utf8_nonnull utf8_pure utf8_weak void *utf8chr(const void *src, long chr);
+utf8_nonnull utf8_pure utf8_weak void *utf8chr(const void *src, int32_t chr);
 
 // Return less than 0, 0, greater than 0 if src1 < src2,
 // src1 == src2, src1 > src2 respectively.
@@ -150,21 +157,21 @@ utf8_nonnull utf8_pure utf8_weak void *utf8valid(const void *str);
 // Sets out_codepoint to the next utf8 codepoint in str, and returns the address
 // of the utf8 codepoint after the current one in str.
 utf8_nonnull utf8_weak void *utf8codepoint(const void *utf8_restrict str,
-                                           int *utf8_restrict out_codepoint);
+                                           int32_t *utf8_restrict out_codepoint);
 
 // Returns the size of the given codepoint in bytes.
-utf8_weak size_t utf8codepointsize(int chr);
+utf8_weak size_t utf8codepointsize(int32_t chr);
 
 // Write a codepoint to the given string, and return the address to the next place
 // after the written codepoint. Pass how many bytes left in the buffer to n. If there
 // is not enough space for the codepoint, this function returns null.
-utf8_nonnull utf8_weak void *utf8catcodepoint(void *utf8_restrict str, int chr, size_t n);
+utf8_nonnull utf8_weak void *utf8catcodepoint(void *utf8_restrict str, int32_t chr, size_t n);
 
 // Returns 1 if the given character is lowercase, or 0 if it is not.
-utf8_weak int utf8islower(int chr);
+utf8_weak int utf8islower(int32_t chr);
 
 // Returns 1 if the given character is uppercase, or 0 if it is not.
-utf8_weak int utf8isupper(int chr);
+utf8_weak int utf8isupper(int32_t chr);
 
 // Transform the given string into all lowercase codepoints.
 utf8_nonnull utf8_weak void utf8lwr(void *utf8_restrict str);
@@ -226,7 +233,7 @@ void *utf8cat(void *utf8_restrict dst, const void *utf8_restrict src) {
   return dst;
 }
 
-void *utf8chr(const void *src, long chr) {
+void *utf8chr(const void *src, int32_t chr) {
   char c[5] = {'\0', '\0', '\0', '\0', '\0'};
 
   if (0 == chr) {
@@ -237,16 +244,16 @@ void *utf8chr(const void *src, long chr) {
       s++;
     }
     return (void *)s;
-  } else if (0 == ((long)0xffffff80 & chr)) {
+  } else if (0 == ((int32_t)0xffffff80 & chr)) {
     // 1-byte/7-bit ascii
     // (0b0xxxxxxx)
     c[0] = (char)chr;
-  } else if (0 == ((long)0xfffff800 & chr)) {
+  } else if (0 == ((int32_t)0xfffff800 & chr)) {
     // 2-byte/11-bit utf8 code point
     // (0b110xxxxx 0b10xxxxxx)
     c[0] = 0xc0 | (char)(chr >> 6);
     c[1] = 0x80 | (char)(chr & 0x3f);
-  } else if (0 == ((long)0xffff0000 & chr)) {
+  } else if (0 == ((int32_t)0xffff0000 & chr)) {
     // 3-byte/16-bit utf8 code point
     // (0b1110xxxx 0b10xxxxxx 0b10xxxxxx)
     c[0] = 0xe0 | (char)(chr >> 12);
@@ -845,7 +852,7 @@ void *utf8valid(const void *str) {
 }
 
 void *utf8codepoint(const void *utf8_restrict str,
-                    int *utf8_restrict out_codepoint) {
+                    int32_t *utf8_restrict out_codepoint) {
   const char *s = (const char *)str;
 
   if (0xf0 == (0xf8 & s[0])) {
@@ -871,22 +878,22 @@ void *utf8codepoint(const void *utf8_restrict str,
   return (void *)s;
 }
 
-size_t utf8codepointsize(int chr) {
-  if (0 == ((int)0xffffff80 & chr)) {
+size_t utf8codepointsize(int32_t chr) {
+  if (0 == ((int32_t)0xffffff80 & chr)) {
     return 1;
-  } else if (0 == ((int)0xfffff800 & chr)) {
+  } else if (0 == ((int32_t)0xfffff800 & chr)) {
     return 2;
-  } else if (0 == ((int)0xffff0000 & chr)) {
+  } else if (0 == ((int32_t)0xffff0000 & chr)) {
     return 3;
   } else { // if (0 == ((int)0xffe00000 & chr)) {
     return 4;
   }
 }
 
-void *utf8catcodepoint(void *utf8_restrict str, int chr, size_t n) {
+void *utf8catcodepoint(void *utf8_restrict str, int32_t chr, size_t n) {
   char *s = (char *)str;
 
-  if (0 == ((int)0xffffff80 & chr)) {
+  if (0 == ((int32_t)0xffffff80 & chr)) {
     // 1-byte/7-bit ascii
     // (0b0xxxxxxx)
     if (n < 1) {
@@ -894,7 +901,7 @@ void *utf8catcodepoint(void *utf8_restrict str, int chr, size_t n) {
     }
     s[0] = (char)chr;
     s += 1;
-  } else if (0 == ((int)0xfffff800 & chr)) {
+  } else if (0 == ((int32_t)0xfffff800 & chr)) {
     // 2-byte/11-bit utf8 code point
     // (0b110xxxxx 0b10xxxxxx)
     if (n < 2) {
@@ -903,7 +910,7 @@ void *utf8catcodepoint(void *utf8_restrict str, int chr, size_t n) {
     s[0] = 0xc0 | (char)(chr >> 6);
     s[1] = 0x80 | (char)(chr & 0x3f);
     s += 2;
-  } else if (0 == ((int)0xffff0000 & chr)) {
+  } else if (0 == ((int32_t)0xffff0000 & chr)) {
     // 3-byte/16-bit utf8 code point
     // (0b1110xxxx 0b10xxxxxx 0b10xxxxxx)
     if (n < 3) {
@@ -929,7 +936,7 @@ void *utf8catcodepoint(void *utf8_restrict str, int chr, size_t n) {
   return s;
 }
 
-int utf8islower(int chr)
+int utf8islower(int32_t chr)
 {
   if (('A' <= chr) && ('Z' >= chr)) {
     return 0;
@@ -938,7 +945,7 @@ int utf8islower(int chr)
   return 1;
 }
 
-int utf8isupper(int chr)
+int utf8isupper(int32_t chr)
 {
   if (('A' <= chr) && ('Z' >= chr)) {
     return 1;


### PR DESCRIPTION
As discussed earlier in #25, I didn't mark these as "complete" in the readme because they really only cover the `A-Za-z` range. `utf8islower` is dumb and only returns `0` for every codepoint in the `A-Z` range.

The upside is that we can use these functions on any utf-8 string or codepoint and they will include any ascii characters.

Thoughts?