### PR TITLE
Bug preventing needle from being found.

### DIFF
--- a/utf8.h
+++ b/utf8.h
@@ -742,7 +742,7 @@ void *utf8casestr(const void *haystack, const void *needle) {
     const char *maybeMatch = h;
     const char *n = (const char *)needle;
 
-    for (;;) {
+    for (; '\0' != *h && '\0' != *n;) {
       char a = *h;
       char b = *n;
       // not entirely correct, but good enough


### PR DESCRIPTION
The utf8casestr function had a bug that prevented needle from being found in haystack when the needle existed at the end of haystack. This commit fixes that.

For example, the string "Hi\0" (null-terminator for emphasis) as the haystack and "HI\0" as the needle where the needle is stored in dynamic memory and haystack may or may not be. utf8casestr will continue going as long as they are both equal, even if they continue being equal past their actual lengths. However, once needle is not equivalent to '\0' after the end of the string, it determines that the needle did not exist in the haystack.