### PR TITLE
Fix the utf8ncpy overrun problem by making the function less awful C.

### DIFF
--- a/test/main.c
+++ b/test/main.c
@@ -845,6 +845,16 @@ UTEST(utf8ncpy, check_no_buffer_overflow) {
   ASSERT_EQ((char)0xdd, buffer[10]);
 }
 
+UTEST(utf8ncpy, check_no_n_overflow) {
+  char buffer[4] = {1, 2, 3, 4};
+  ASSERT_EQ(buffer, utf8ncpy(buffer, "foo", 2));
+
+  ASSERT_EQ('f', buffer[0]);
+  ASSERT_EQ('o', buffer[1]);
+  ASSERT_EQ(3, buffer[2]);
+  ASSERT_EQ(4, buffer[3]);
+}
+
 UTEST(utf8pbrk, pbrk) { ASSERT_EQ(data + 8, utf8pbrk(data, pbrk)); }
 
 UTEST(utf8pbrk, data) { ASSERT_EQ(data, utf8pbrk(data, data)); }

--- a/utf8.h
+++ b/utf8.h
@@ -578,16 +578,20 @@ void *utf8ncpy(void *utf8_restrict dst, const void *utf8_restrict src,
                size_t n) {
   char *d = (char *)dst;
   const char *s = (const char *)src;
+  size_t index;
 
   // overwriting anything previously in dst, write byte-by-byte
   // from src
-  do {
-    *d++ = *s++;
-  } while (('\0' != *s) && (0 != --n));
+  for (index = 0; index < n; index++) {
+    d[index] = s[index];
+    if ('\0' == s[index]) {
+      break;
+    }
+  }
 
   // append null terminating byte
-  while (0 != --n) {
-    *d++ = '\0';
+  for (; index < n; index++) {
+    d[index] = 0;
   }
 
   return dst;


### PR DESCRIPTION
Fixes #52.