### PR TITLE
Fix for utf8str when the needle partially matches (foobar, oba)

### DIFF
--- a/test/main.c
+++ b/test/main.c
@@ -61,6 +61,8 @@ const char ascii1[] = "I lIke GOATS YARHAR.";
 const char ascii2[] = "i LIKE goats yarHAR.";
 const char allascii1[] = "abcdefghijklmnopqrstuvwyzABCDEFGHIJKLMNOPQRSTUVWYZ";
 const char allascii2[] = "ABCDEFGHIJKLMNOPQRSTUVWYZabcdefghijklmnopqrstuvwyz";
+const char haystack[] = "foobar";
+const char needle[] = "oba";
 
 struct LowerUpperPair {
   int lower;
@@ -535,11 +537,15 @@ UTEST(utf8str, test) { ASSERT_EQ((void *)0, utf8str(data, "test")); }
 
 UTEST(utf8str, empty) { ASSERT_EQ(data, utf8str(data, "")); }
 
+UTEST(utf8str, partial) { ASSERT_EQ(haystack + 2, utf8str(haystack, needle)); }
+
 UTEST(utf8casestr, cmp) { ASSERT_EQ(data + 21, utf8casestr(data, cmp)); }
 
 UTEST(utf8casestr, test) { ASSERT_EQ((void *)0, utf8casestr(data, "test")); }
 
 UTEST(utf8casestr, empty) { ASSERT_EQ(data, utf8casestr(data, "")); }
+
+UTEST(utf8casestr, partial) { ASSERT_EQ(haystack + 2, utf8casestr(haystack, needle)); }
 
 UTEST(utf8casestr, latin) {
   ASSERT_EQ(lowersStr, utf8casestr(lowersStr, uppersStr));

--- a/utf8.h
+++ b/utf8.h
@@ -858,7 +858,8 @@ void *utf8casestr(const void *haystack, const void *needle) {
     const void *n = needle;
     utf8_int32_t h_cp, n_cp;
 
-    h = utf8codepoint(h, &h_cp);
+    // Get the next code point and track it
+    const void *nextH = h = utf8codepoint(h, &h_cp);
     n = utf8codepoint(n, &n_cp);
 
     while ((0 != h_cp) && (0 != n_cp)) {
@@ -884,6 +885,9 @@ void *utf8casestr(const void *haystack, const void *needle) {
       // no match
       return utf8_null;
     }
+
+    // Roll back to the next code point in the haystack to test
+    h = nextH;
   }
 }
 

--- a/utf8.h
+++ b/utf8.h
@@ -829,7 +829,9 @@ void *utf8str(const void *haystack, const void *needle) {
       return (void *)maybeMatch;
     } else {
       // h could be in the middle of an unmatching utf8 codepoint,
-      // so we need to march it on to the next character beginning,
+      // so we need to march it on to the next character beginning
+      // starting from the current character
+      h = maybeMatch;
       if ('\0' != *h) {
         do {
           h++;


### PR DESCRIPTION
Without this fix, utf8str( "foobar", "oba" ) returned NULL.