### PR TITLE
Utf8str infinite loop

### DIFF
--- a/test/main.c
+++ b/test/main.c
@@ -63,6 +63,7 @@ const char allascii1[] = "abcdefghijklmnopqrstuvwyzABCDEFGHIJKLMNOPQRSTUVWYZ";
 const char allascii2[] = "ABCDEFGHIJKLMNOPQRSTUVWYZabcdefghijklmnopqrstuvwyz";
 const char haystack[] = "foobar";
 const char needle[] = "oba";
+const char endfailneedle[] = "ra";
 
 struct LowerUpperPair {
   int lower;
@@ -539,6 +540,8 @@ UTEST(utf8str, empty) { ASSERT_EQ(data, utf8str(data, "")); }
 
 UTEST(utf8str, partial) { ASSERT_EQ(haystack + 2, utf8str(haystack, needle)); }
 
+UTEST(utf8str, endfail) { ASSERT_EQ((void *)0, utf8str(haystack, endfailneedle)); }
+
 UTEST(utf8casestr, cmp) { ASSERT_EQ(data + 21, utf8casestr(data, cmp)); }
 
 UTEST(utf8casestr, test) { ASSERT_EQ((void *)0, utf8casestr(data, "test")); }
@@ -546,6 +549,8 @@ UTEST(utf8casestr, test) { ASSERT_EQ((void *)0, utf8casestr(data, "test")); }
 UTEST(utf8casestr, empty) { ASSERT_EQ(data, utf8casestr(data, "")); }
 
 UTEST(utf8casestr, partial) { ASSERT_EQ(haystack + 2, utf8casestr(haystack, needle)); }
+
+UTEST(utf8casestr, endfail) { ASSERT_EQ((void *)0, utf8casestr(haystack, endfailneedle)); }
 
 UTEST(utf8casestr, latin) {
   ASSERT_EQ(lowersStr, utf8casestr(lowersStr, uppersStr));

--- a/utf8.h
+++ b/utf8.h
@@ -829,7 +829,9 @@ void *utf8str(const void *haystack, const void *needle) {
       return (void *)maybeMatch;
     } else {
       // h could be in the middle of an unmatching utf8 codepoint,
-      // so we need to march it on to the next character beginning,
+      // so we need to march it on to the next character beginning
+      // starting from the previous character
+      h = maybeMatch;
       if ('\0' != *h) {
         do {
           h++;

--- a/utf8.h
+++ b/utf8.h
@@ -814,6 +814,7 @@ void *utf8str(const void *haystack, const void *needle) {
     return (void *)haystack;
   }
 
+  utf8_int32_t h_cp;
   while ('\0' != *h) {
     const char *maybeMatch = h;
     const char *n = (const char *)needle;
@@ -831,12 +832,7 @@ void *utf8str(const void *haystack, const void *needle) {
       // h could be in the middle of an unmatching utf8 codepoint,
       // so we need to march it on to the next character beginning
       // starting from the current character
-      h = maybeMatch;
-      if ('\0' != *h) {
-        do {
-          h++;
-        } while (0x80 == (0xc0 & *h));
-      }
+      h = (const char*)utf8codepoint(maybeMatch, &h_cp);
     }
   }
 


### PR DESCRIPTION
Fixed edge case when trying to use "foobar" as a haystack and "ra" as a needle