### PR TITLE
Fix for utf8spn not matching ASCII characters

### DIFF
--- a/test/main.c
+++ b/test/main.c
@@ -66,6 +66,8 @@ const char needle[] = "oba";
 const char endfailneedle[] = "ra";
 const char cspnmultisearch[] = "another test; string|one more";
 const char cspnmultidelims[] = "|;";
+const char spnasciisearch[] = ",,hello,,world";
+const char spnasciidelims[] = ",";
 
 
 struct LowerUpperPair {
@@ -579,11 +581,14 @@ UTEST(utf8cpy, data) {
   ASSERT_EQ(53, utf8len(utf8cpy(cpy, data)));
 }
 
-UTEST(utf8spn, spn) { ASSERT_EQ(7, utf8spn(data, spn)); }
+// Matches \xce\x93 \xce\xb1 \xce\xb6 \xce\xad \xce\xb5 \xcf\x82 \x20 \xce\xba \xce\xb1 
+UTEST(utf8spn, spn) { ASSERT_EQ(9, utf8spn(data, spn)); }
 
-UTEST(utf8spn, data) { ASSERT_EQ(52, utf8spn(data, data)); }
+UTEST(utf8spn, data) { ASSERT_EQ(53, utf8spn(data, data)); }
 
 UTEST(utf8spn, ascii) { ASSERT_EQ(0, utf8spn(data, "ab")); }
+
+UTEST(utf8spn, spnasciisearch) { ASSERT_EQ(2, utf8spn(spnasciisearch, spnasciidelims)); }
 
 UTEST(utf8cspn, spn) { ASSERT_EQ(0, utf8cspn(data, spn)); }
 

--- a/utf8.h
+++ b/utf8.h
@@ -778,6 +778,7 @@ size_t utf8spn(const void *src, const void *accept) {
         // codepoints in a match
         chars++;
         s += offset;
+        offset = 0;
         break;
       } else {
         if (*a == s[offset]) {
@@ -794,6 +795,13 @@ size_t utf8spn(const void *src, const void *accept) {
           offset = 0;
         }
       }
+    }
+
+    // found a match at the end of *a, so didn't get a chance to test it
+    if (0 < offset) {
+        chars++;
+        s += offset;
+        continue;
     }
 
     // if a got to its terminating null byte, then we didn't find a match.


### PR DESCRIPTION
This example shows why the previous test values were off by one:

```
#include <iostream>
#include <string.h>

using namespace std;

int main()
{
    auto len = strspn("abcdefg", "abc");
    cout<< len << endl; // 3
    
    len = strspn("abcdefg", "abcdefg");
    cout<< len; // 7

    return 0;
}
```
