### PR TITLE
docs: fix simple typo, occurence -> occurrence

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ string if `n` falls partway through a utf8 codepoint.
 ```c
 void *utf8pbrk(const void *str, const void *accept);
 ```
-Locates the first occurence in the utf8 string `str` of any byte in the   
+Locates the first occurrence in the utf8 string `str` of any byte in the   
 utf8 string `accept`, or 0 if no match was found.
 
 ```c

--- a/utf8.h
+++ b/utf8.h
@@ -149,7 +149,7 @@ utf8_nonnull utf8_weak void *utf8ncpy(void *utf8_restrict dst,
 // Returns a new string if successful, 0 otherwise
 utf8_nonnull utf8_weak void *utf8ndup(const void *src, size_t n);
 
-// Locates the first occurence in the utf8 string str of any byte in the
+// Locates the first occurrence in the utf8 string str of any byte in the
 // utf8 string accept, or 0 if no match was found.
 utf8_nonnull utf8_pure utf8_weak void *utf8pbrk(const void *str,
                                                 const void *accept);


### PR DESCRIPTION
There is a small typo in README.md, utf8.h.

Should read `occurrence` rather than `occurence`.

