### PR TITLE
utf8ncpy fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,12 +145,10 @@ bytes of each utf8 string.
 void *utf8ncpy(void *dst, const void *src, size_t n);
 ```
 Copy the utf8 string `src` onto the memory allocated in `dst`.   
-Copies at most `n` bytes. If there is no terminating null byte in   
-the first `n` bytes of `src`, the string placed into `dst` will not be   
-null-terminated. If the size (in bytes) of `src` is less than `n`,   
-extra null terminating bytes are appended to `dst` such that at   
-total of `n` bytes are written. Can produce an invalid utf8   
-string if `n` falls partway through a utf8 codepoint.
+Copies at most `n` bytes. If `n` falls partway through a utf8
+codepoint, or if `dst` doesn't have enough room for a null
+terminator, the final string will be cut short to preserve
+utf8 validity.
 
 ```c
 void *utf8pbrk(const void *str, const void *accept);

--- a/test/main.c
+++ b/test/main.c
@@ -1033,28 +1033,30 @@ UTEST(utf8ncpy, check_no_n_overflow) {
 
 UTEST(utf8ncpy, truncated_copy_valid) {
   char cpy1[32] = {'\0'};
+  char cpy2[3] = {'\0'};
+  char cpy3[1] = {'\0'};
+
   utf8ncpy(cpy1, data, 32);
   ASSERT_EQ(0, utf8valid(cpy1));
 
-  char cpy2[3] = {'\0'};
   utf8ncpy(cpy2, data, 3);
   ASSERT_EQ(0, utf8valid(cpy2));
 
-  char cpy3[1] = {'\0'};
   utf8ncpy(cpy3, data, 1);
   ASSERT_EQ(0, utf8valid(cpy3));
 }
 
 UTEST(utf8ncpy, truncated_copy_null_terminated) {
   char cpy1[32] = {'\0'};
+  char cpy2[2] = {'\0'};
+  char cpy3[3] = {'\0'};
+
   utf8ncpy(cpy1, data, 32);
   ASSERT_EQ('\0', cpy1[31]);
 
-  char cpy2[2] = {'\0'};
   utf8ncpy(cpy2, data, 2);
   ASSERT_EQ('\0', cpy2[0]);
 
-  char cpy3[3] = {'\0'};
   utf8ncpy(cpy3, data, 3);
   ASSERT_EQ('\0', cpy3[2]);
 }

--- a/test/main.c
+++ b/test/main.c
@@ -1031,6 +1031,34 @@ UTEST(utf8ncpy, check_no_n_overflow) {
   ASSERT_EQ(4, buffer[3]);
 }
 
+UTEST(utf8ncpy, truncated_copy_valid) {
+  char cpy1[32] = {'\0'};
+  utf8ncpy(cpy1, data, 32);
+  ASSERT_EQ(0, utf8valid(cpy1));
+
+  char cpy2[3] = {'\0'};
+  utf8ncpy(cpy2, data, 3);
+  ASSERT_EQ(0, utf8valid(cpy2));
+
+  char cpy3[1] = {'\0'};
+  utf8ncpy(cpy3, data, 1);
+  ASSERT_EQ(0, utf8valid(cpy3));
+}
+
+UTEST(utf8ncpy, truncated_copy_null_terminated) {
+  char cpy1[32] = {'\0'};
+  utf8ncpy(cpy1, data, 32);
+  ASSERT_EQ('\0', cpy1[31]);
+
+  char cpy2[2] = {'\0'};
+  utf8ncpy(cpy2, data, 2);
+  ASSERT_EQ('\0', cpy2[0]);
+
+  char cpy3[3] = {'\0'};
+  utf8ncpy(cpy3, data, 3);
+  ASSERT_EQ('\0', cpy3[2]);
+}
+
 UTEST(utf8pbrk, pbrk) { ASSERT_EQ(data + 8, utf8pbrk(data, pbrk)); }
 
 UTEST(utf8pbrk, data) { ASSERT_EQ(data, utf8pbrk(data, data)); }

--- a/utf8.h
+++ b/utf8.h
@@ -580,7 +580,7 @@ void *utf8ncpy(void *utf8_restrict dst, const void *utf8_restrict src,
                size_t n) {
   char *d = (char *)dst;
   const char *s = (const char *)src;
-  size_t index;
+  size_t index, check_index;
 
   // overwriting anything previously in dst, write byte-by-byte
   // from src
@@ -589,6 +589,11 @@ void *utf8ncpy(void *utf8_restrict dst, const void *utf8_restrict src,
     if ('\0' == s[index]) {
       break;
     }
+  }
+
+  for ( check_index = index - 1; check_index > 0 && 0x80 == (0xc0 & d[check_index]); check_index--);
+  if (check_index < index && (index - check_index) < utf8codepointsize(d[check_index])) {
+    index = check_index;
   }
 
   // append null terminating byte

--- a/utf8.h
+++ b/utf8.h
@@ -590,7 +590,10 @@ void *utf8ncpy(void *utf8_restrict dst, const void *utf8_restrict src,
     }
   }
 
-  for ( check_index = index - 1; check_index > 0 && 0x80 == (0xc0 & d[check_index]); check_index--);
+  for ( check_index = index - 1; check_index > 0 && 0x80 == (0xc0 & d[check_index]); check_index--) {
+    // just moving the index
+  }
+
   if (check_index < index && (index - check_index) < utf8codepointsize(d[check_index])) {
     index = check_index;
   }

--- a/utf8.h
+++ b/utf8.h
@@ -140,13 +140,12 @@ utf8_nonnull utf8_weak void *utf8ncat(void *utf8_restrict dst,
 utf8_nonnull utf8_pure utf8_weak int utf8ncmp(const void *src1,
                                               const void *src2, size_t n);
 
-// Copy the utf8 string src onto the memory allocated in dst.
-// Copies at most n bytes. If there is no terminating null byte in
-// the first n bytes of src, the string placed into dst will not be
-// null-terminated. If the size (in bytes) of src is less than n,
-// extra null terminating bytes are appended to dst such that at
-// total of n bytes are written. Can produce an invalid utf8
-// string if n falls partway through a utf8 codepoint.
+// Copy the utf8 string src onto the memory allocated in dst.   
+// Copies at most n bytes. If n falls partway through a utf8
+// codepoint, or if dst doesn't have enough room for a null
+// terminator, the final string will be cut short to preserve
+// utf8 validity.
+
 utf8_nonnull utf8_weak void *utf8ncpy(void *utf8_restrict dst,
                                       const void *utf8_restrict src, size_t n);
 


### PR DESCRIPTION
Prevent utf8ncpy producing an invalid utf8 string if destination buffer size cut short a codepoint or didn't leave room for a null terminator