### PR TITLE
Add a function to get the previous codepoint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Functions provided that are unique to utf8.h:
 utf8.h | complete
 -------|---------
 utf8codepoint | &#10004;
+utf8rcodepoint | &#10004;
 utf8size | &#10004;
 utf8valid | &#10004;
 utf8codepointsize | &#10004;
@@ -192,8 +193,14 @@ Return 0 on success, or the position of the invalid utf8 codepoint on failure.
 ```c
 void *utf8codepoint(const void *str, long *out_codepoint);
 ```
-Sets out_codepoint to the next utf8 codepoint in `str`,    
-and returns the address of the utf8 codepoint after the current one in `str`.
+Sets out_codepoint to the current utf8 codepoint in `str`, and returns the
+address of the next utf8 codepoint after the current one in `str`.
+
+```c
+void *utf8rcodepoint(const void *str, long *out_codepoint);
+```
+Sets out_codepoint to the current utf8 codepoint in `str`, and returns the
+address of the previous utf8 codepoint before the current one in `str`.
 
 ```c
 utf8_weak size_t utf8codepointsize(utf8_int32_t chr);

--- a/test/main.c
+++ b/test/main.c
@@ -1303,4 +1303,20 @@ UTEST(utf8ncasecmp, greek_capital_theta) {
   ASSERT_EQ(0, utf8ncasecmp(ref, str, 8));
 }
 
+UTEST(utf8rcodepoint, ascii) {
+  utf8_int32_t codepoint;
+
+  ASSERT_EQ(ascii1, utf8rcodepoint(ascii1 + 1, &codepoint));
+
+  ASSERT_EQ(ascii1[1], codepoint);
+}
+
+UTEST(utf8rcodepoint, latin) {
+  utf8_int32_t codepoint;
+
+  ASSERT_EQ(data, utf8rcodepoint(data + 2, &codepoint));
+
+  ASSERT_EQ(0x3B1, codepoint);
+}
+
 UTEST_MAIN();


### PR DESCRIPTION
`utf8rcodepoint`

Fixes #61.