### PR TITLE
Add constexpr to most functions (use char8_t for C++20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,58 +10,58 @@ Functions provided from the C header string.h but with a utf8* prefix instead of
 
 [API function docs](#api-function-docs)
 
-string.h | utf8.h | complete
----------|--------|---------
-strcat | utf8cat | &#10004;
-strchr | utf8chr | &#10004;
-strcmp | utf8cmp | &#10004;
-strcoll | utf8coll |
-strcpy | utf8cpy | &#10004;
-strcspn | utf8cspn | &#10004;
-strdup | utf8dup | &#10004;
-strfry | utf8fry |
-strlen | utf8len | &#10004;
-strnlen | utf8nlen | &#10004;
-strncat | utf8ncat | &#10004;
-strncmp | utf8ncmp | &#10004;
-strncpy | utf8ncpy | &#10004;
-strndup | utf8ndup | &#10004;
-strpbrk | utf8pbrk | &#10004;
-strrchr | utf8rchr | &#10004;
-strsep | utf8sep |
-strspn | utf8spn | &#10004;
-strstr | utf8str | &#10004;
-strtok | utf8tok |
-strxfrm | utf8xfrm |
+string.h | utf8.h | complete | C++14 constexpr
+---------|--------|---------|---------
+strcat | utf8cat | &#10004; |
+strchr | utf8chr | &#10004; | &#10004;
+strcmp | utf8cmp | &#10004; | &#10004;
+strcoll | utf8coll | |
+strcpy | utf8cpy | &#10004; |
+strcspn | utf8cspn | &#10004; | &#10004;
+strdup | utf8dup | &#10004; |
+strfry | utf8fry | |
+strlen | utf8len | &#10004; | &#10004;
+strnlen | utf8nlen | &#10004; | &#10004;
+strncat | utf8ncat | &#10004; |
+strncmp | utf8ncmp | &#10004; | &#10004;
+strncpy | utf8ncpy | &#10004; |
+strndup | utf8ndup | &#10004; |
+strpbrk | utf8pbrk | &#10004; | &#10004;
+strrchr | utf8rchr | &#10004; | &#10004;
+strsep | utf8sep | |
+strspn | utf8spn | &#10004; | &#10004;
+strstr | utf8str | &#10004; | &#10004;
+strtok | utf8tok | |
+strxfrm | utf8xfrm | |
 
 Functions provided from the C header strings.h but with a utf8* prefix instead of the str* prefix:
 
-strings.h | utf8.h | complete
-----------|--------|---------
-strcasecmp | utf8casecmp | ~~&#10004;~~
-strncasecmp | utf8ncasecmp | ~~&#10004;~~
-strcasestr | utf8casestr | ~~&#10004;~~
+strings.h | utf8.h | complete | C++14 constexpr
+----------|--------|---------|---------
+strcasecmp | utf8casecmp | ~~&#10004;~~ | &#10004;
+strncasecmp | utf8ncasecmp | ~~&#10004;~~ | &#10004;
+strcasestr | utf8casestr | ~~&#10004;~~ | &#10004;
 
 Functions provided that are unique to utf8.h:
 
-utf8.h | complete
--------|---------
-utf8codepoint | &#10004;
-utf8rcodepoint | &#10004;
-utf8size | &#10004;
-utf8size\_lazy | &#10004;
-utf8nsize\_lazy | &#10004;
-utf8valid | &#10004;
-utf8nvalid | &#10004;
-utf8makevalid | &#10004;
-utf8codepointsize | &#10004;
-utf8catcodepoint | &#10004;
-utf8isupper |  ~~&#10004;~~
-utf8islower | ~~&#10004;~~
-utf8lwr | ~~&#10004;~~
-utf8upr | ~~&#10004;~~
-utf8lwrcodepoint | ~~&#10004;~~
-utf8uprcodepoint | ~~&#10004;~~
+utf8.h | complete | C++14 constexpr
+-------|---------|---------
+utf8codepoint | &#10004; | &#10004;
+utf8rcodepoint | &#10004; | &#10004;
+utf8size | &#10004; | &#10004;
+utf8size\_lazy | &#10004; | &#10004;
+utf8nsize\_lazy | &#10004; | &#10004;
+utf8valid | &#10004; | &#10004;
+utf8nvalid | &#10004; | &#10004;
+utf8makevalid | &#10004; |
+utf8codepointsize | &#10004; | &#10004;
+utf8catcodepoint | &#10004; |
+utf8isupper |  ~~&#10004;~~ | &#10004;
+utf8islower | ~~&#10004;~~ | &#10004;
+utf8lwr | ~~&#10004;~~ |
+utf8upr | ~~&#10004;~~ |
+utf8lwrcodepoint | ~~&#10004;~~ | &#10004;
+utf8uprcodepoint | ~~&#10004;~~ | &#10004;
 
 ## Usage ##
 
@@ -75,7 +75,7 @@ The current supported compilers are gcc, clang, MSVC's cl.exe, and clang-cl.exe.
 
 The utf8.h API matches the string.h API as much as possible by design. There are a few major differences though.
 
-I use void* instead of char* when passing around utf8 strings. My reasoning is that I really don't want people accidentally thinking they can use integer arthimetic on the pointer and always get a valid character like you would with an ASCII string. Having it as a void* forces a user to explicitly cast the utf8 string to char* such that the onus is on them not to break the code anymore!
+utf8.h uses char8_t* in C++ 20 instead of char*
 
 Anywhere in the string.h or strings.h documentation where it refers to 'bytes' I have changed that to utf8 codepoints. For instance, utf8len will return the number of utf8 codepoints in a utf8 string - which does not necessarily equate to the number of bytes.
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,10 +33,14 @@ add_executable(utf8_test
   test.c
 )
 
-add_executable(utf8_test_cpp
+add_executable(utf8_test_cpp14
     test.cpp
 )
-target_compile_features(utf8_test_cpp PRIVATE cxx_std_14)
+target_compile_features(utf8_test_cpp14 PRIVATE cxx_std_14)
+add_executable(utf8_test_cpp20
+    test.cpp
+    )
+target_compile_features(utf8_test_cpp20 PRIVATE cxx_std_20)
 
 if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
   set_source_files_properties(test.c test.cpp PROPERTIES

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -48,7 +48,7 @@ elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
   )
 elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
   set_source_files_properties(test.c test.cpp PROPERTIES
-    COMPILE_FLAGS "/Wall /WX /wd4514"
+    COMPILE_FLAGS "/Wall /WX /wd4514 /Zc:__cplusplus"
   )
 else()
   message(WARNING "Unknown compiler '${CMAKE_C_COMPILER_ID}'!")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -35,12 +35,14 @@ add_executable(utf8_test
 
 add_executable(utf8_test_cpp14
     test.cpp
-)
-target_compile_features(utf8_test_cpp14 PRIVATE cxx_std_14)
+    )
+set_target_properties(utf8_test_cpp14 PROPERTIES CXX_STANDARD 14)
+
 add_executable(utf8_test_cpp20
     test.cpp
     )
-target_compile_features(utf8_test_cpp20 PRIVATE cxx_std_20)
+set_target_properties(utf8_test_cpp20 PROPERTIES CXX_STANDARD 20)
+
 
 if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
   set_source_files_properties(test.c test.cpp PROPERTIES
@@ -52,8 +54,13 @@ elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
   )
 elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
   set_source_files_properties(test.c test.cpp PROPERTIES
-    COMPILE_FLAGS "/Wall /WX /wd4514 /Zc:__cplusplus"
+    COMPILE_FLAGS "/Wall /WX /wd4514"
   )
+  if(${MSVC_VERSION} VERSION_GREATER "15.7")
+    set_source_files_properties(test.c test.cpp PROPERTIES
+        COMPILE_FLAGS "/Zc:__cplusplus"
+        )
+  endif()
 else()
   message(WARNING "Unknown compiler '${CMAKE_C_COMPILER_ID}'!")
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,8 +31,12 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/..)
 add_executable(utf8_test
   main.c
   test.c
-  test.cpp
 )
+
+add_executable(utf8_test_cpp
+    test.cpp
+)
+target_compile_features(utf8_test_cpp PRIVATE cxx_std_14)
 
 if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
   set_source_files_properties(test.c test.cpp PROPERTIES
@@ -40,7 +44,7 @@ if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
   )
 elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
   set_source_files_properties(test.c test.cpp PROPERTIES
-    COMPILE_FLAGS "-Wall -Wextra -Weverything -Werror"
+    COMPILE_FLAGS "-Wall -Wextra -Weverything -Werror -Wno-c++98-compat"
   )
 elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
   set_source_files_properties(test.c test.cpp PROPERTIES

--- a/test/main.c
+++ b/test/main.c
@@ -798,7 +798,7 @@ UTEST(utf8ndup, ascii_larger) {
   free(dup);
 }
 
-void *allocate_from_buffer(void *user_data, size_t n) { return user_data; }
+utf8_int8_t *allocate_from_buffer(utf8_int8_t *user_data, size_t n) { return user_data; }
 
 UTEST(utf8dup_ex, ascii) {
   char user_data[1024];

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -25,4 +25,48 @@
 
 #include "utf8.h"
 
-int main() {}
+#if __cplusplus >= 202002L
+using char_type = char8_t;
+#else
+using char_type = char;
+#endif
+
+
+// We don't care about the results. We only want to check compilation
+
+constexpr void test()
+{
+    constexpr char_type in_str[20]{};
+    constexpr utf8_int32_t in_chr{};
+    utf8_int32_t out_chr{};
+
+    utf8codepoint(in_str, &out_chr);
+    utf8rcodepoint(in_str, &out_chr);
+    static_assert(utf8chr(in_str, utf8_int32_t{}), "utf8 constexpr fail");
+    static_assert(utf8cmp(in_str, in_str) == 0, "utf8 constexpr fail");
+    static_assert(utf8cspn(in_str, in_str) == 0, "utf8 constexpr fail");
+    static_assert(utf8len(in_str) == 0, "utf8 constexpr fail");
+    static_assert(utf8nlen(in_str, 1) == 0, "utf8 constexpr fail");
+    static_assert(utf8ncmp(in_str, in_str, 1) == 0, "utf8 constexpr fail");
+    static_assert(utf8pbrk(in_str, in_str) == nullptr, "utf8 constexpr fail");
+    static_assert(utf8rchr(in_str, 1) == nullptr, "utf8 constexpr fail");
+    static_assert(utf8spn(in_str, in_str) == 0, "utf8 constexpr fail");
+    static_assert(utf8str(in_str, in_str), "utf8 constexpr fail");
+    static_assert(utf8casecmp(in_str, in_str) == 0, "utf8 constexpr fail");
+    static_assert(utf8ncasecmp(in_str, in_str, 1) == 0, "utf8 constexpr fail");
+    static_assert(utf8casestr(in_str, in_str), "utf8 constexpr fail");
+    static_assert(utf8size(in_str), "utf8 constexpr fail");
+    static_assert(utf8size_lazy(in_str) == 0, "utf8 constexpr faillazy;");
+    static_assert(utf8nsize_lazy(in_str, 1) == 0, "utf8 constexpr faillazy;");
+    static_assert(utf8valid(in_str) == nullptr, "utf8 constexpr fail");
+    static_assert(utf8nvalid(in_str, 1) == nullptr, "utf8 constexpr fail");
+    static_assert(utf8codepointsize(in_chr), "utf8 constexpr fail");
+    static_assert(utf8isupper(in_chr) == false, "utf8 constexpr fail");
+    static_assert(utf8islower(in_chr) == false, "utf8 constexpr fail");
+    static_assert(utf8lwrcodepoint(in_chr) == in_chr, "utf8 constexpr fail");
+    static_assert(utf8uprcodepoint(in_chr) == in_chr, "utf8 constexpr fail");
+}
+
+int main() {
+    test();
+}

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -24,3 +24,5 @@
 // For more information, please refer to <http://unlicense.org/>
 
 #include "utf8.h"
+
+int main() {}

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -25,18 +25,11 @@
 
 #include "utf8.h"
 
-#if __cplusplus >= 202002L
-using char_type = char8_t;
-#else
-using char_type = char;
-#endif
-
-
 // We don't care about the results. We only want to check compilation
 
 constexpr void test()
 {
-    constexpr char_type in_str[20]{};
+    constexpr utf8_int8_t in_str[20]{};
     constexpr utf8_int32_t in_chr{};
     utf8_int32_t out_chr{};
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -27,6 +27,7 @@
 
 // We don't care about the results. We only want to check compilation
 
+#if defined (__cplusplus) && __cplusplus >= 201402L
 constexpr void test()
 {
     constexpr utf8_int8_t in_str[20]{};
@@ -59,6 +60,9 @@ constexpr void test()
     static_assert(utf8lwrcodepoint(in_chr) == in_chr, "utf8 constexpr fail");
     static_assert(utf8uprcodepoint(in_chr) == in_chr, "utf8 constexpr fail");
 }
+#else
+void test(){};
+#endif
 
 int main() {
     test();

--- a/utf8.h
+++ b/utf8.h
@@ -87,7 +87,7 @@ extern "C" {
 #define utf8_null 0
 #endif
 
-#if defined(__cplusplus) && __cplusplus >= 201402L
+#if (defined(__cplusplus) && __cplusplus >= 201402L)
 #define utf8_constexpr14 constexpr
 #define utf8_constexpr14_impl constexpr
 #else

--- a/utf8.h
+++ b/utf8.h
@@ -306,17 +306,15 @@ utf8_constexpr14 int utf8casecmp(const utf8_int8_t *src1, const utf8_int8_t *src
 }
 
 utf8_int8_t *utf8cat(utf8_int8_t *utf8_restrict dst, const utf8_int8_t *utf8_restrict src) {
-  utf8_int8_t *d = (utf8_int8_t *)dst;
-  const utf8_int8_t *s = (const utf8_int8_t *)src;
-
+  utf8_int8_t *d = dst;
   // find the null terminating byte in dst
   while ('\0' != *d) {
     d++;
   }
 
   // overwriting the null terminating byte in dst, append src byte-by-byte
-  while ('\0' != *s) {
-    *d++ = *s++;
+  while ('\0' != *src) {
+    *d++ = *src++;
   }
 
   // write out a new null terminating byte into dst
@@ -331,11 +329,10 @@ utf8_constexpr14 utf8_int8_t *utf8chr(const utf8_int8_t *src, utf8_int32_t chr) 
   if (0 == chr) {
     // being asked to return position of null terminating byte, so
     // just run s to the end, and return!
-    const utf8_int8_t *s = (const utf8_int8_t *)src;
-    while ('\0' != *s) {
-      s++;
+    while ('\0' != *src) {
+      src++;
     }
-    return (utf8_int8_t *)s;
+    return (utf8_int8_t *)src;
   } else if (0 == ((utf8_int32_t)0xffffff80 & chr)) {
     // 1-byte/7-bit ascii
     // (0b0xxxxxxx)
@@ -367,18 +364,15 @@ utf8_constexpr14 utf8_int8_t *utf8chr(const utf8_int8_t *src, utf8_int32_t chr) 
 }
 
 utf8_constexpr14 int utf8cmp(const utf8_int8_t *src1, const utf8_int8_t *src2) {
-  const utf8_int8_t *s1 = (const utf8_int8_t *)src1;
-  const utf8_int8_t *s2 = (const utf8_int8_t *)src2;
-
-  while (('\0' != *s1) || ('\0' != *s2)) {
-    if (*s1 < *s2) {
+  while (('\0' != *src1) || ('\0' != *src2)) {
+    if (*src1 < *src2) {
       return -1;
-    } else if (*s1 > *s2) {
+    } else if (*src1 > *src2) {
       return 1;
     }
 
-    s1++;
-    s2++;
+    src1++;
+    src2++;
   }
 
   // both utf8 strings matched
@@ -388,13 +382,12 @@ utf8_constexpr14 int utf8cmp(const utf8_int8_t *src1, const utf8_int8_t *src2) {
 utf8_constexpr14 int utf8coll(const utf8_int8_t *src1, const utf8_int8_t *src2);
 
 utf8_int8_t *utf8cpy(utf8_int8_t *utf8_restrict dst, const utf8_int8_t *utf8_restrict src) {
-  utf8_int8_t *d = (utf8_int8_t *)dst;
-  const utf8_int8_t *s = (const utf8_int8_t *)src;
+  utf8_int8_t *d = dst;
 
   // overwriting anything previously in dst, write byte-by-byte
   // from src
-  while ('\0' != *s) {
-    *d++ = *s++;
+  while ('\0' != *src) {
+    *d++ = *src++;
   }
 
   // append null terminating byte
@@ -404,11 +397,10 @@ utf8_int8_t *utf8cpy(utf8_int8_t *utf8_restrict dst, const utf8_int8_t *utf8_res
 }
 
 utf8_constexpr14 size_t utf8cspn(const utf8_int8_t *src, const utf8_int8_t *reject) {
-  const utf8_int8_t *s = (const utf8_int8_t *)src;
   size_t chars = 0;
 
-  while ('\0' != *s) {
-    const utf8_int8_t *r = (const utf8_int8_t *)reject;
+  while ('\0' != *src) {
+    const utf8_int8_t *r = reject;
     size_t offset = 0;
 
     while ('\0' != *r) {
@@ -418,7 +410,7 @@ utf8_constexpr14 size_t utf8cspn(const utf8_int8_t *src, const utf8_int8_t *reje
       if ((0x80 != (0xc0 & *r)) && (0 < offset)) {
         return chars;
       } else {
-        if (*r == s[offset]) {
+        if (*r == src[offset]) {
           // part of a utf8 codepoint matched, so move our checking
           // onwards to the next byte
           offset++;
@@ -446,8 +438,8 @@ utf8_constexpr14 size_t utf8cspn(const utf8_int8_t *src, const utf8_int8_t *reje
     // could have been partway through a utf8 codepoint, so we need to
     // march it onto the next utf8 codepoint starting byte
     do {
-      s++;
-    } while ((0x80 == (0xc0 & *s)));
+      src++;
+    } while ((0x80 == (0xc0 & *src)));
     chars++;
   }
 
@@ -458,14 +450,13 @@ utf8_int8_t *utf8dup(const utf8_int8_t *src) { return utf8dup_ex(src, utf8_null,
 
 utf8_int8_t *utf8dup_ex(const utf8_int8_t *src, utf8_int8_t *(*alloc_func_ptr)(utf8_int8_t *, size_t),
                                   utf8_int8_t *user_data) {
-  const utf8_int8_t *s = (const utf8_int8_t *)src;
   utf8_int8_t *n = utf8_null;
 
   // figure out how many bytes (including the terminator) we need to copy first
   size_t bytes = utf8size(src);
 
   if (alloc_func_ptr) {
-    n = (utf8_int8_t *)alloc_func_ptr(user_data, bytes);
+    n = alloc_func_ptr(user_data, bytes);
   } else {
     n = (utf8_int8_t *)malloc(bytes);
   }
@@ -477,8 +468,8 @@ utf8_int8_t *utf8dup_ex(const utf8_int8_t *src, utf8_int8_t *(*alloc_func_ptr)(u
     bytes = 0;
 
     // copy src byte-by-byte into our new utf8 string
-    while ('\0' != s[bytes]) {
-      n[bytes] = s[bytes];
+    while ('\0' != src[bytes]) {
+      n[bytes] = src[bytes];
       bytes++;
     }
 
@@ -495,23 +486,22 @@ utf8_constexpr14 size_t utf8len(const utf8_int8_t *str) {
 }
 
 utf8_constexpr14 size_t utf8nlen(const utf8_int8_t *str, size_t n) {
-  const utf8_int8_t *s = (const utf8_int8_t *)str;
-  const utf8_int8_t *t = s;
+  const utf8_int8_t *t = str;
   size_t length = 0;
 
-  while ((size_t) (s-t) < n && '\0' != *s) {
-    if (0xf0 == (0xf8 & *s)) {
+  while ((size_t) (str-t) < n && '\0' != *str) {
+    if (0xf0 == (0xf8 & *str)) {
       // 4-byte utf8 code point (began with 0b11110xxx)
-      s += 4;
-    } else if (0xe0 == (0xf0 & *s)) {
+      str += 4;
+    } else if (0xe0 == (0xf0 & *str)) {
       // 3-byte utf8 code point (began with 0b1110xxxx)
-      s += 3;
-    } else if (0xc0 == (0xe0 & *s)) {
+      str += 3;
+    } else if (0xc0 == (0xe0 & *str)) {
       // 2-byte utf8 code point (began with 0b110xxxxx)
-      s += 2;
+      str += 2;
     } else { // if (0x00 == (0x80 & *s)) {
       // 1-byte ascii (began with 0b0xxxxxxx)
-      s += 1;
+      str += 1;
     }
 
     // no matter the bytes we marched s forward by, it was
@@ -519,7 +509,7 @@ utf8_constexpr14 size_t utf8nlen(const utf8_int8_t *str, size_t n) {
     length++;
   }
 
-  if ((size_t) (s-t) > n) {
+  if ((size_t) (str-t) > n) {
     length--;
   }
   return length;
@@ -530,8 +520,8 @@ utf8_constexpr14 int utf8ncasecmp(const utf8_int8_t *src1, const utf8_int8_t *sr
         src1_orig_cp = 0, src2_orig_cp = 0;
 
   do {
-    const utf8_int8_t *const s1 = (const utf8_int8_t *)src1;
-    const utf8_int8_t *const s2 = (const utf8_int8_t *)src2;
+    const utf8_int8_t *const s1 = src1;
+    const utf8_int8_t *const s2 = src2;
 
     // first check that we have enough bytes left in n to contain an entire
     // codepoint
@@ -599,8 +589,7 @@ utf8_constexpr14 int utf8ncasecmp(const utf8_int8_t *src1, const utf8_int8_t *sr
 
 utf8_int8_t *utf8ncat(utf8_int8_t *utf8_restrict dst, const utf8_int8_t *utf8_restrict src,
                size_t n) {
-  utf8_int8_t *d = (utf8_int8_t *)dst;
-  const utf8_int8_t *s = (const utf8_int8_t *)src;
+  utf8_int8_t *d = dst;
 
   // find the null terminating byte in dst
   while ('\0' != *d) {
@@ -610,8 +599,8 @@ utf8_int8_t *utf8ncat(utf8_int8_t *utf8_restrict dst, const utf8_int8_t *utf8_re
   // overwriting the null terminating byte in dst, append src byte-by-byte
   // stopping if we run out of space
   do {
-    *d++ = *s++;
-  } while (('\0' != *s) && (0 != --n));
+    *d++ = *src++;
+  } while (('\0' != *src) && (0 != --n));
 
   // write out a new null terminating byte into dst
   *d = '\0';
@@ -620,18 +609,15 @@ utf8_int8_t *utf8ncat(utf8_int8_t *utf8_restrict dst, const utf8_int8_t *utf8_re
 }
 
 utf8_constexpr14 int utf8ncmp(const utf8_int8_t *src1, const utf8_int8_t *src2, size_t n) {
-  const utf8_int8_t *s1 = (const utf8_int8_t *)src1;
-  const utf8_int8_t *s2 = (const utf8_int8_t *)src2;
-
-  while ((0 != n--) && (('\0' != *s1) || ('\0' != *s2))) {
-    if (*s1 < *s2) {
+  while ((0 != n--) && (('\0' != *src1) || ('\0' != *src2))) {
+    if (*src1 < *src2) {
       return -1;
-    } else if (*s1 > *s2) {
+    } else if (*src1 > *src2) {
       return 1;
     }
 
-    s1++;
-    s2++;
+    src1++;
+    src2++;
   }
 
   // both utf8 strings matched
@@ -640,8 +626,7 @@ utf8_constexpr14 int utf8ncmp(const utf8_int8_t *src1, const utf8_int8_t *src2, 
 
 utf8_int8_t *utf8ncpy(utf8_int8_t *utf8_restrict dst, const utf8_int8_t *utf8_restrict src,
                size_t n) {
-  utf8_int8_t *d = (utf8_int8_t *)dst;
-  const utf8_int8_t *s = (const utf8_int8_t *)src;
+  utf8_int8_t *d = dst;
   size_t index = 0, check_index = 0;
 
   if (n == 0) {
@@ -651,8 +636,8 @@ utf8_int8_t *utf8ncpy(utf8_int8_t *utf8_restrict dst, const utf8_int8_t *utf8_re
   // overwriting anything previously in dst, write byte-by-byte
   // from src
   for (index = 0; index < n; index++) {
-    d[index] = s[index];
-    if ('\0' == s[index]) {
+    d[index] = src[index];
+    if ('\0' == src[index]) {
       break;
     }
   }
@@ -679,12 +664,11 @@ utf8_int8_t *utf8ndup(const utf8_int8_t *src, size_t n) {
 
 utf8_int8_t *utf8ndup_ex(const utf8_int8_t *src, size_t n,
                   utf8_int8_t *(*alloc_func_ptr)(utf8_int8_t *, size_t), utf8_int8_t *user_data) {
-  const utf8_int8_t *s = (const utf8_int8_t *)src;
   utf8_int8_t *c = utf8_null;
   size_t bytes = 0;
 
   // Find the end of the string or stop when n is reached
-  while ('\0' != s[bytes] && bytes < n) {
+  while ('\0' != src[bytes] && bytes < n) {
     bytes++;
   }
 
@@ -693,7 +677,7 @@ utf8_int8_t *utf8ndup_ex(const utf8_int8_t *src, size_t n,
   n = bytes;
 
   if (alloc_func_ptr) {
-    c = (utf8_int8_t *)alloc_func_ptr(user_data, bytes + 1);
+    c = alloc_func_ptr(user_data, bytes + 1);
   } else {
     c = (utf8_int8_t *)malloc(bytes + 1);
   }
@@ -706,8 +690,8 @@ utf8_int8_t *utf8ndup_ex(const utf8_int8_t *src, size_t n,
   bytes = 0;
 
   // copy src byte-by-byte into our new utf8 string
-  while ('\0' != s[bytes] && bytes < n) {
-    c[bytes] = s[bytes];
+  while ('\0' != src[bytes] && bytes < n) {
+    c[bytes] = src[bytes];
     bytes++;
   }
 
@@ -717,17 +701,17 @@ utf8_int8_t *utf8ndup_ex(const utf8_int8_t *src, size_t n,
 }
 
 utf8_constexpr14 utf8_int8_t *utf8rchr(const utf8_int8_t *src, int chr) {
-  const utf8_int8_t *s = (const utf8_int8_t *)src;
+
   const utf8_int8_t *match = utf8_null;
   utf8_int8_t c[5] = {'\0', '\0', '\0', '\0', '\0'};
 
   if (0 == chr) {
     // being asked to return position of null terminating byte, so
     // just run s to the end, and return!
-    while ('\0' != *s) {
-      s++;
+    while ('\0' != *src) {
+      src++;
     }
-    return (utf8_int8_t *)s;
+    return (utf8_int8_t *)src;
   } else if (0 == ((int)0xffffff80 & chr)) {
     // 1-byte/7-bit ascii
     // (0b0xxxxxxx)
@@ -756,26 +740,26 @@ utf8_constexpr14 utf8_int8_t *utf8rchr(const utf8_int8_t *src, int chr) {
   // the utf8 character asked for by chr, and a null
   // terminating byte
 
-  while ('\0' != *s) {
+  while ('\0' != *src) {
     size_t offset = 0;
 
-    while (s[offset] == c[offset]) {
+    while (src[offset] == c[offset]) {
       offset++;
     }
 
     if ('\0' == c[offset]) {
       // we found a matching utf8 code point
-      match = s;
-      s += offset;
+      match = src;
+      src += offset;
     } else {
-      s += offset;
+      src += offset;
 
       // need to march s along to next utf8 codepoint start
       // (the next byte that doesn't match 0b10xxxxxx)
-      if ('\0' != *s) {
+      if ('\0' != *src) {
         do {
-          s++;
-        } while (0x80 == (0xc0 & *s));
+          src++;
+        } while (0x80 == (0xc0 & *src));
       }
     }
   }
@@ -785,10 +769,8 @@ utf8_constexpr14 utf8_int8_t *utf8rchr(const utf8_int8_t *src, int chr) {
 }
 
 utf8_constexpr14 utf8_int8_t *utf8pbrk(const utf8_int8_t *str, const utf8_int8_t *accept) {
-  const utf8_int8_t *s = (const utf8_int8_t *)str;
-
-  while ('\0' != *s) {
-    const utf8_int8_t *a = (const utf8_int8_t *)accept;
+  while ('\0' != *str) {
+    const utf8_int8_t *a = accept;
     size_t offset = 0;
 
     while ('\0' != *a) {
@@ -796,9 +778,9 @@ utf8_constexpr14 utf8_int8_t *utf8pbrk(const utf8_int8_t *str, const utf8_int8_t
       // (it is not 0b10xxxxxx) and we have successfully matched
       // a previous character (0 < offset) - we found a match
       if ((0x80 != (0xc0 & *a)) && (0 < offset)) {
-        return (utf8_int8_t *)s;
+        return (utf8_int8_t *)str;
       } else {
-        if (*a == s[offset]) {
+        if (*a == str[offset]) {
           // part of a utf8 codepoint matched, so move our checking
           // onwards to the next byte
           offset++;
@@ -819,15 +801,15 @@ utf8_constexpr14 utf8_int8_t *utf8pbrk(const utf8_int8_t *str, const utf8_int8_t
 
     // we found a match on the last utf8 codepoint
     if (0 < offset) {
-      return (utf8_int8_t *)s;
+      return (utf8_int8_t *)str;
     }
 
     // the current utf8 codepoint in src did not match accept, but src
     // could have been partway through a utf8 codepoint, so we need to
     // march it onto the next utf8 codepoint starting byte
     do {
-      s++;
-    } while ((0x80 == (0xc0 & *s)));
+      str++;
+    } while ((0x80 == (0xc0 & *str)));
   }
 
   return utf8_null;
@@ -842,20 +824,18 @@ utf8_constexpr14 size_t utf8size_lazy(const utf8_int8_t *str) {
 }
 
 utf8_constexpr14 size_t utf8nsize_lazy(const utf8_int8_t *str, size_t n) {
-  const utf8_int8_t *s = (const utf8_int8_t *)str;
   size_t size = 0;
-  while (size < n && '\0' != s[size]) {
+  while (size < n && '\0' != str[size]) {
     size++;
   }
   return size;
 }
 
 utf8_constexpr14 size_t utf8spn(const utf8_int8_t *src, const utf8_int8_t *accept) {
-  const utf8_int8_t *s = (const utf8_int8_t *)src;
   size_t chars = 0;
 
-  while ('\0' != *s) {
-    const utf8_int8_t *a = (const utf8_int8_t *)accept;
+  while ('\0' != *src) {
+    const utf8_int8_t *a = accept;
     size_t offset = 0;
 
     while ('\0' != *a) {
@@ -867,11 +847,11 @@ utf8_constexpr14 size_t utf8spn(const utf8_int8_t *src, const utf8_int8_t *accep
         // that have matched and stop checking whether any other utf8
         // codepoints in a match
         chars++;
-        s += offset;
+        src += offset;
         offset = 0;
         break;
       } else {
-        if (*a == s[offset]) {
+        if (*a == src[offset]) {
           offset++;
           a++;
         } else {
@@ -890,7 +870,7 @@ utf8_constexpr14 size_t utf8spn(const utf8_int8_t *src, const utf8_int8_t *accep
     // found a match at the end of *a, so didn't get a chance to test it
     if (0 < offset) {
       chars++;
-      s += offset;
+      src += offset;
       continue;
     }
 
@@ -905,22 +885,21 @@ utf8_constexpr14 size_t utf8spn(const utf8_int8_t *src, const utf8_int8_t *accep
 }
 
 utf8_constexpr14 utf8_int8_t *utf8str(const utf8_int8_t *haystack, const utf8_int8_t *needle) {
-  const utf8_int8_t *h = (const utf8_int8_t *)haystack;
   utf8_int32_t throwaway_codepoint = 0;
 
   // if needle has no utf8 codepoints before the null terminating
   // byte then return haystack
-  if ('\0' == *((const utf8_int8_t *)needle)) {
+  if ('\0' == *needle) {
     return (utf8_int8_t *)haystack;
   }
 
-  while ('\0' != *h) {
-    const utf8_int8_t *maybeMatch = h;
-    const utf8_int8_t *n = (const utf8_int8_t *)needle;
+  while ('\0' != *haystack) {
+    const utf8_int8_t *maybeMatch = haystack;
+    const utf8_int8_t *n = needle;
 
-    while (*h == *n && (*h != '\0' && *n != '\0')) {
+    while (*haystack == *n && (*haystack != '\0' && *n != '\0')) {
       n++;
-      h++;
+      haystack++;
     }
 
     if ('\0' == *n) {
@@ -931,7 +910,7 @@ utf8_constexpr14 utf8_int8_t *utf8str(const utf8_int8_t *haystack, const utf8_in
       // h could be in the middle of an unmatching utf8 codepoint,
       // so we need to march it on to the next character beginning
       // starting from the current character
-      h = (const utf8_int8_t *)utf8codepoint(maybeMatch, &throwaway_codepoint);
+      haystack = utf8codepoint(maybeMatch, &throwaway_codepoint);
     }
   }
 
@@ -940,21 +919,19 @@ utf8_constexpr14 utf8_int8_t *utf8str(const utf8_int8_t *haystack, const utf8_in
 }
 
 utf8_constexpr14 utf8_int8_t *utf8casestr(const utf8_int8_t *haystack, const utf8_int8_t *needle) {
-  const utf8_int8_t *h = haystack;
-
   // if needle has no utf8 codepoints before the null terminating
   // byte then return haystack
-  if ('\0' == *((const utf8_int8_t *)needle)) {
+  if ('\0' == *needle) {
     return (utf8_int8_t *)haystack;
   }
 
   for (;;) {
-    const utf8_int8_t *maybeMatch = h;
+    const utf8_int8_t *maybeMatch = haystack;
     const utf8_int8_t *n = needle;
     utf8_int32_t h_cp = 0, n_cp = 0;
 
     // Get the next code point and track it
-    const utf8_int8_t *nextH = h = utf8codepoint(h, &h_cp);
+    const utf8_int8_t *nextH = haystack = utf8codepoint(haystack, &h_cp);
     n = utf8codepoint(n, &n_cp);
 
     while ((0 != h_cp) && (0 != n_cp)) {
@@ -966,7 +943,7 @@ utf8_constexpr14 utf8_int8_t *utf8casestr(const utf8_int8_t *haystack, const utf
         break;
       }
 
-      h = utf8codepoint(h, &h_cp);
+      haystack = utf8codepoint(haystack, &h_cp);
       n = utf8codepoint(n, &n_cp);
     }
 
@@ -982,7 +959,7 @@ utf8_constexpr14 utf8_int8_t *utf8casestr(const utf8_int8_t *haystack, const utf
     }
 
     // Roll back to the next code point in the haystack to test
-    h = nextH;
+    haystack = nextH;
   }
 }
 
@@ -991,98 +968,97 @@ utf8_constexpr14 utf8_int8_t *utf8valid(const utf8_int8_t *str) {
 }
 
 utf8_constexpr14 utf8_int8_t *utf8nvalid(const utf8_int8_t *str, size_t n) {
-  const utf8_int8_t *s = (const utf8_int8_t *)str;
-  const utf8_int8_t *t = s;
+  const utf8_int8_t *t = str;
   size_t consumed = 0, remained = 0;
 
-  while ((void) (consumed = (size_t) (s-t)), consumed < n && '\0' != *s) {
+  while ((void) (consumed = (size_t) (str-t)), consumed < n && '\0' != *str) {
     remained = n - consumed;
 
-    if (0xf0 == (0xf8 & *s)) {
+    if (0xf0 == (0xf8 & *str)) {
       // ensure that there's 4 bytes or more remained
       if (remained < 4) {
-        return (utf8_int8_t *)s;
+        return (utf8_int8_t *)str;
       }
 
       // ensure each of the 3 following bytes in this 4-byte
       // utf8 codepoint began with 0b10xxxxxx
-      if ((0x80 != (0xc0 & s[1])) || (0x80 != (0xc0 & s[2])) ||
-          (0x80 != (0xc0 & s[3]))) {
-        return (utf8_int8_t *)s;
+      if ((0x80 != (0xc0 & str[1])) || (0x80 != (0xc0 & str[2])) ||
+          (0x80 != (0xc0 & str[3]))) {
+        return (utf8_int8_t *)str;
       }
 
       // ensure that our utf8 codepoint ended after 4 bytes
-      if (0x80 == (0xc0 & s[4])) {
-        return (utf8_int8_t *)s;
+      if (0x80 == (0xc0 & str[4])) {
+        return (utf8_int8_t *)str;
       }
 
       // ensure that the top 5 bits of this 4-byte utf8
       // codepoint were not 0, as then we could have used
       // one of the smaller encodings
-      if ((0 == (0x07 & s[0])) && (0 == (0x30 & s[1]))) {
-        return (utf8_int8_t *)s;
+      if ((0 == (0x07 & str[0])) && (0 == (0x30 & str[1]))) {
+        return (utf8_int8_t *)str;
       }
 
       // 4-byte utf8 code point (began with 0b11110xxx)
-      s += 4;
-    } else if (0xe0 == (0xf0 & *s)) {
+      str += 4;
+    } else if (0xe0 == (0xf0 & *str)) {
       // ensure that there's 3 bytes or more remained
       if (remained < 3) {
-        return (utf8_int8_t *)s;
+        return (utf8_int8_t *)str;
       }
 
       // ensure each of the 2 following bytes in this 3-byte
       // utf8 codepoint began with 0b10xxxxxx
-      if ((0x80 != (0xc0 & s[1])) || (0x80 != (0xc0 & s[2]))) {
-        return (utf8_int8_t *)s;
+      if ((0x80 != (0xc0 & str[1])) || (0x80 != (0xc0 & str[2]))) {
+        return (utf8_int8_t *)str;
       }
 
       // ensure that our utf8 codepoint ended after 3 bytes
-      if (0x80 == (0xc0 & s[3])) {
-        return (utf8_int8_t *)s;
+      if (0x80 == (0xc0 & str[3])) {
+        return (utf8_int8_t *)str;
       }
 
       // ensure that the top 5 bits of this 3-byte utf8
       // codepoint were not 0, as then we could have used
       // one of the smaller encodings
-      if ((0 == (0x0f & s[0])) && (0 == (0x20 & s[1]))) {
-        return (utf8_int8_t *)s;
+      if ((0 == (0x0f & str[0])) && (0 == (0x20 & str[1]))) {
+        return (utf8_int8_t *)str;
       }
 
       // 3-byte utf8 code point (began with 0b1110xxxx)
-      s += 3;
-    } else if (0xc0 == (0xe0 & *s)) {
+      str += 3;
+    } else if (0xc0 == (0xe0 & *str)) {
       // ensure that there's 2 bytes or more remained
       if (remained < 2) {
-        return (utf8_int8_t *)s;
+        return (utf8_int8_t *)str;
       }
 
       // ensure the 1 following byte in this 2-byte
       // utf8 codepoint began with 0b10xxxxxx
-      if (0x80 != (0xc0 & s[1])) {
-        return (utf8_int8_t *)s;
+      if (0x80 != (0xc0 & str[1])) {
+        return (utf8_int8_t *)str;
       }
 
       // ensure that our utf8 codepoint ended after 2 bytes
-      if (0x80 == (0xc0 & s[2])) {
-        return (utf8_int8_t *)s;
+      if (0x80 == (0xc0 & str[2])) {
+        return (utf8_int8_t *)str;
       }
 
       // ensure that the top 4 bits of this 2-byte utf8
       // codepoint were not 0, as then we could have used
       // one of the smaller encodings
-      if (0 == (0x1e & s[0])) {
-        return (utf8_int8_t *)s;
+      if (0 == (0x1e & str[0])) {
+        return (utf8_int8_t *)str;
       }
 
       // 2-byte utf8 code point (began with 0b110xxxxx)
-      s += 2;
-    } else if (0x00 == (0x80 & *s)) {
+      str += 2;
+    } else if (0x00 == (0x80 & *str)) {
       // 1-byte ascii (began with 0b0xxxxxxx)
-      s += 1;
+      str += 1;
     } else {
       // we have an invalid 0b1xxxxxxx utf8 code point entry
-      return (utf8_int8_t *)s;
+      return (utf8_int8_t *)str;
     }
   }
 
@@ -1090,7 +1066,7 @@ utf8_constexpr14 utf8_int8_t *utf8nvalid(const utf8_int8_t *str, size_t n) {
 }
 
 int utf8makevalid(utf8_int8_t *str, const utf8_int32_t replacement) {
-  utf8_int8_t *read = (utf8_int8_t *)str;
+  utf8_int8_t *read = str;
   utf8_int8_t *write = read;
   const utf8_int8_t r = (utf8_int8_t) replacement;
   utf8_int32_t codepoint = 0;
@@ -1111,8 +1087,8 @@ int utf8makevalid(utf8_int8_t *str, const utf8_int32_t replacement) {
       }
 
       // 4-byte utf8 code point (began with 0b11110xxx)
-      read = (utf8_int8_t *)utf8codepoint(read, &codepoint);
-      write = (utf8_int8_t *)utf8catcodepoint(write, codepoint, 4);
+      read = utf8codepoint(read, &codepoint);
+      write = utf8catcodepoint(write, codepoint, 4);
     } else if (0xe0 == (0xf0 & *read)) {
       // ensure each of the 2 following bytes in this 3-byte
       // utf8 codepoint began with 0b10xxxxxx
@@ -1123,8 +1099,8 @@ int utf8makevalid(utf8_int8_t *str, const utf8_int32_t replacement) {
       }
 
       // 3-byte utf8 code point (began with 0b1110xxxx)
-      read = (utf8_int8_t *)utf8codepoint(read, &codepoint);
-      write = (utf8_int8_t *)utf8catcodepoint(write, codepoint, 3);
+      read = utf8codepoint(read, &codepoint);
+      write = utf8catcodepoint(write, codepoint, 3);
     } else if (0xc0 == (0xe0 & *read)) {
       // ensure the 1 following byte in this 2-byte
       // utf8 codepoint began with 0b10xxxxxx
@@ -1135,12 +1111,12 @@ int utf8makevalid(utf8_int8_t *str, const utf8_int32_t replacement) {
       }
 
       // 2-byte utf8 code point (began with 0b110xxxxx)
-      read = (utf8_int8_t *)utf8codepoint(read, &codepoint);
-      write = (utf8_int8_t *)utf8catcodepoint(write, codepoint, 2);
+      read = utf8codepoint(read, &codepoint);
+      write = utf8catcodepoint(write, codepoint, 2);
     } else if (0x00 == (0x80 & *read)) {
       // 1-byte ascii (began with 0b0xxxxxxx)
-      read = (utf8_int8_t *)utf8codepoint(read, &codepoint);
-      write = (utf8_int8_t *)utf8catcodepoint(write, codepoint, 1);
+      read = utf8codepoint(read, &codepoint);
+      write = utf8catcodepoint(write, codepoint, 1);
     } else {
       // if we got here then we've got a dangling continuation (0b10xxxxxx)
       *write++ = r;
@@ -1156,41 +1132,37 @@ int utf8makevalid(utf8_int8_t *str, const utf8_int32_t replacement) {
 
 utf8_constexpr14 utf8_int8_t *utf8codepoint(const utf8_int8_t *utf8_restrict str,
                                      utf8_int32_t *utf8_restrict out_codepoint) {
-  const utf8_int8_t *s = (const utf8_int8_t *)str;
-
-  if (0xf0 == (0xf8 & s[0])) {
+  if (0xf0 == (0xf8 & str[0])) {
     // 4 byte utf8 codepoint
-    *out_codepoint = ((0x07 & s[0]) << 18) | ((0x3f & s[1]) << 12) |
-                     ((0x3f & s[2]) << 6) | (0x3f & s[3]);
-    s += 4;
-  } else if (0xe0 == (0xf0 & s[0])) {
+    *out_codepoint = ((0x07 & str[0]) << 18) | ((0x3f & str[1]) << 12) |
+                     ((0x3f & str[2]) << 6) | (0x3f & str[3]);
+    str += 4;
+  } else if (0xe0 == (0xf0 & str[0])) {
     // 3 byte utf8 codepoint
     *out_codepoint =
-        ((0x0f & s[0]) << 12) | ((0x3f & s[1]) << 6) | (0x3f & s[2]);
-    s += 3;
-  } else if (0xc0 == (0xe0 & s[0])) {
+        ((0x0f & str[0]) << 12) | ((0x3f & str[1]) << 6) | (0x3f & str[2]);
+    str += 3;
+  } else if (0xc0 == (0xe0 & str[0])) {
     // 2 byte utf8 codepoint
-    *out_codepoint = ((0x1f & s[0]) << 6) | (0x3f & s[1]);
-    s += 2;
+    *out_codepoint = ((0x1f & str[0]) << 6) | (0x3f & str[1]);
+    str += 2;
   } else {
     // 1 byte utf8 codepoint otherwise
-    *out_codepoint = s[0];
-    s += 1;
+    *out_codepoint = str[0];
+    str += 1;
   }
 
-  return (utf8_int8_t *)s;
+  return (utf8_int8_t *)str;
 }
 
 utf8_constexpr14 size_t utf8codepointcalcsize(const utf8_int8_t *str) {
-  const utf8_int8_t *s = (const utf8_int8_t *)str;
-
-  if (0xf0 == (0xf8 & s[0])) {
+  if (0xf0 == (0xf8 & str[0])) {
     // 4 byte utf8 codepoint
     return 4;
-  } else if (0xe0 == (0xf0 & s[0])) {
+  } else if (0xe0 == (0xf0 & str[0])) {
     // 3 byte utf8 codepoint
     return 3;
-  } else if (0xc0 == (0xe0 & s[0])) {
+  } else if (0xc0 == (0xe0 & str[0])) {
     // 2 byte utf8 codepoint
     return 2;
   }
@@ -1212,49 +1184,47 @@ utf8_constexpr14 size_t utf8codepointsize(utf8_int32_t chr) {
 }
 
 utf8_int8_t *utf8catcodepoint(utf8_int8_t *str, utf8_int32_t chr, size_t n) {
-  utf8_int8_t *s = (utf8_int8_t *)str;
-
   if (0 == ((utf8_int32_t)0xffffff80 & chr)) {
     // 1-byte/7-bit ascii
     // (0b0xxxxxxx)
     if (n < 1) {
       return utf8_null;
     }
-    s[0] = (utf8_int8_t) chr;
-    s += 1;
+    str[0] = (utf8_int8_t) chr;
+    str += 1;
   } else if (0 == ((utf8_int32_t)0xfffff800 & chr)) {
     // 2-byte/11-bit utf8 code point
     // (0b110xxxxx 0b10xxxxxx)
     if (n < 2) {
       return utf8_null;
     }
-    s[0] = (utf8_int8_t)  (0xc0 | (utf8_int8_t) ((chr >> 6) & 0x1f));
-    s[1] = (utf8_int8_t)  (0x80 | (utf8_int8_t) (chr & 0x3f));
-    s += 2;
+    str[0] = (utf8_int8_t)  (0xc0 | (utf8_int8_t) ((chr >> 6) & 0x1f));
+    str[1] = (utf8_int8_t)  (0x80 | (utf8_int8_t) (chr & 0x3f));
+    str += 2;
   } else if (0 == ((utf8_int32_t)0xffff0000 & chr)) {
     // 3-byte/16-bit utf8 code point
     // (0b1110xxxx 0b10xxxxxx 0b10xxxxxx)
     if (n < 3) {
       return utf8_null;
     }
-    s[0] = (utf8_int8_t)  (0xe0 | (utf8_int8_t) ((chr >> 12) & 0x0f));
-    s[1] = (utf8_int8_t)  (0x80 | (utf8_int8_t) ((chr >> 6) & 0x3f));
-    s[2] = (utf8_int8_t)  (0x80 | (utf8_int8_t) (chr & 0x3f));
-    s += 3;
+    str[0] = (utf8_int8_t)  (0xe0 | (utf8_int8_t) ((chr >> 12) & 0x0f));
+    str[1] = (utf8_int8_t)  (0x80 | (utf8_int8_t) ((chr >> 6) & 0x3f));
+    str[2] = (utf8_int8_t)  (0x80 | (utf8_int8_t) (chr & 0x3f));
+    str += 3;
   } else { // if (0 == ((int)0xffe00000 & chr)) {
     // 4-byte/21-bit utf8 code point
     // (0b11110xxx 0b10xxxxxx 0b10xxxxxx 0b10xxxxxx)
     if (n < 4) {
       return utf8_null;
     }
-    s[0] = (utf8_int8_t)  (0xf0 | (utf8_int8_t) ((chr >> 18) & 0x07));
-    s[1] = (utf8_int8_t)  (0x80 | (utf8_int8_t) ((chr >> 12) & 0x3f));
-    s[2] = (utf8_int8_t)  (0x80 | (utf8_int8_t) ((chr >> 6) & 0x3f));
-    s[3] = (utf8_int8_t)  (0x80 | (utf8_int8_t) (chr & 0x3f));
-    s += 4;
+    str[0] = (utf8_int8_t)  (0xf0 | (utf8_int8_t) ((chr >> 18) & 0x07));
+    str[1] = (utf8_int8_t)  (0x80 | (utf8_int8_t) ((chr >> 12) & 0x3f));
+    str[2] = (utf8_int8_t)  (0x80 | (utf8_int8_t) ((chr >> 6) & 0x3f));
+    str[3] = (utf8_int8_t)  (0x80 | (utf8_int8_t) (chr & 0x3f));
+    str += 4;
   }
 
-  return s;
+  return str;
 }
 
 utf8_constexpr14 int utf8islower(utf8_int32_t chr) { return chr != utf8uprcodepoint(chr); }
@@ -1262,42 +1232,36 @@ utf8_constexpr14 int utf8islower(utf8_int32_t chr) { return chr != utf8uprcodepo
 utf8_constexpr14 int utf8isupper(utf8_int32_t chr) { return chr != utf8lwrcodepoint(chr); }
 
 void utf8lwr(utf8_int8_t *utf8_restrict str) {
-  utf8_int8_t *p = utf8_null, *pn = utf8_null;
   utf8_int32_t cp = 0;
-
-  p = (utf8_int8_t *)str;
-  pn = utf8codepoint(p, &cp);
+  utf8_int8_t *pn = utf8codepoint(str, &cp);
 
   while (cp != 0) {
     const utf8_int32_t lwr_cp = utf8lwrcodepoint(cp);
     const size_t size = utf8codepointsize(lwr_cp);
 
     if (lwr_cp != cp) {
-      utf8catcodepoint(p, lwr_cp, size);
+      utf8catcodepoint(str, lwr_cp, size);
     }
 
-    p = pn;
-    pn = utf8codepoint(p, &cp);
+    str = pn;
+    pn = utf8codepoint(str, &cp);
   }
 }
 
 void utf8upr(utf8_int8_t *utf8_restrict str) {
-  utf8_int8_t *p = utf8_null, *pn = utf8_null;
   utf8_int32_t cp = 0;
-
-  p = (utf8_int8_t *)str;
-  pn = utf8codepoint(p, &cp);
+  utf8_int8_t *pn = utf8codepoint(str, &cp);
 
   while (cp != 0) {
     const utf8_int32_t lwr_cp = utf8uprcodepoint(cp);
     const size_t size = utf8codepointsize(lwr_cp);
 
     if (lwr_cp != cp) {
-      utf8catcodepoint(p, lwr_cp, size);
+      utf8catcodepoint(str, lwr_cp, size);
     }
 
-    p = pn;
-    pn = utf8codepoint(p, &cp);
+    str = pn;
+    pn = utf8codepoint(str, &cp);
   }
 }
 

--- a/utf8.h
+++ b/utf8.h
@@ -93,130 +93,139 @@ extern "C" {
 #define utf8_constexpr14
 #endif
 
+#if defined(__cplusplus) && __cplusplus >= 202002L
+using utf8_t = char8_t; // Introduced in C++20
+#elif defined(__cplusplus)
+using utf8_t = char; // constexpr does not allow cast from void *
+#else
+typedef void utf8_t;
+#endif
+
+
 // Return less than 0, 0, greater than 0 if src1 < src2, src1 == src2, src1 >
 // src2 respectively, case insensitive.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak int utf8casecmp(const void *src1,
-                                                                  const void *src2);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak int utf8casecmp(const utf8_t *src1,
+                                                                  const utf8_t *src2);
 
 // Append the utf8 string src onto the utf8 string dst.
-utf8_nonnull utf8_weak void *utf8cat(void *utf8_restrict dst,
-                                     const void *utf8_restrict src);
+utf8_nonnull utf8_weak utf8_t *utf8cat(utf8_t *utf8_restrict dst,
+                                       const utf8_t *utf8_restrict src);
 
 // Find the first match of the utf8 codepoint chr in the utf8 string src.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak void *utf8chr(const void *src,
-                                                                utf8_int32_t chr);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak utf8_t *utf8chr(const utf8_t *src,
+                                                                  utf8_int32_t chr);
 
 // Return less than 0, 0, greater than 0 if src1 < src2,
 // src1 == src2, src1 > src2 respectively.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak int utf8cmp(const void *src1,
-                                                              const void *src2);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak int utf8cmp(const utf8_t *src1,
+                                                              const utf8_t *src2);
 
 // Copy the utf8 string src onto the memory allocated in dst.
-utf8_nonnull utf8_weak void *utf8cpy(void *utf8_restrict dst,
-                                     const void *utf8_restrict src);
+utf8_nonnull utf8_weak utf8_t *utf8cpy(utf8_t *utf8_restrict dst,
+                                       const utf8_t *utf8_restrict src);
 
 // Number of utf8 codepoints in the utf8 string src that consists entirely
 // of utf8 codepoints not from the utf8 string reject.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak size_t utf8cspn(const void *src,
-                                                                  const void *reject);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak size_t utf8cspn(const utf8_t *src,
+                                                                  const utf8_t *reject);
 
 // Duplicate the utf8 string src by getting its size, malloc'ing a new buffer
 // copying over the data, and returning that. Or 0 if malloc failed.
-utf8_weak void *utf8dup(const void *src);
+utf8_weak utf8_t *utf8dup(const utf8_t *src);
 
 // Number of utf8 codepoints in the utf8 string str,
 // excluding the null terminating byte.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak size_t utf8len(const void *str);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak size_t utf8len(const utf8_t *str);
 
 // Similar to utf8len, except that only at most n bytes of src are looked.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak size_t utf8nlen(const void *str, size_t n);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak size_t utf8nlen(const utf8_t *str, size_t n);
 
 // Return less than 0, 0, greater than 0 if src1 < src2, src1 == src2, src1 >
 // src2 respectively, case insensitive. Checking at most n bytes of each utf8
 // string.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak int utf8ncasecmp(const void *src1,
-                                                                   const void *src2, size_t n);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak int utf8ncasecmp(const utf8_t *src1,
+                                                                   const utf8_t *src2, size_t n);
 
 // Append the utf8 string src onto the utf8 string dst,
 // writing at most n+1 bytes. Can produce an invalid utf8
 // string if n falls partway through a utf8 codepoint.
-utf8_nonnull utf8_weak void *utf8ncat(void *utf8_restrict dst,
-                                      const void *utf8_restrict src, size_t n);
+utf8_nonnull utf8_weak utf8_t *utf8ncat(utf8_t *utf8_restrict dst,
+                                        const utf8_t *utf8_restrict src, size_t n);
 
 // Return less than 0, 0, greater than 0 if src1 < src2,
 // src1 == src2, src1 > src2 respectively. Checking at most n
 // bytes of each utf8 string.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak int utf8ncmp(const void *src1,
-                                                               const void *src2, size_t n);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak int utf8ncmp(const utf8_t *src1,
+                                                               const utf8_t *src2, size_t n);
 
-// Copy the utf8 string src onto the memory allocated in dst.   
+// Copy the utf8 string src onto the memory allocated in dst.
 // Copies at most n bytes. If n falls partway through a utf8
 // codepoint, or if dst doesn't have enough room for a null
 // terminator, the final string will be cut short to preserve
 // utf8 validity.
 
-utf8_nonnull utf8_weak void *utf8ncpy(void *utf8_restrict dst,
-                                      const void *utf8_restrict src, size_t n);
+utf8_nonnull utf8_weak utf8_t *utf8ncpy(utf8_t *utf8_restrict dst,
+                                        const utf8_t *utf8_restrict src, size_t n);
 
 // Similar to utf8dup, except that at most n bytes of src are copied. If src is
 // longer than n, only n bytes are copied and a null byte is added.
 //
 // Returns a new string if successful, 0 otherwise
-utf8_weak void *utf8ndup(const void *src, size_t n);
+utf8_weak utf8_t *utf8ndup(const utf8_t *src, size_t n);
 
 // Locates the first occurrence in the utf8 string str of any byte in the
 // utf8 string accept, or 0 if no match was found.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak void *utf8pbrk(const void *str,
-                                                const void *accept);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak utf8_t *utf8pbrk(const utf8_t *str,
+                                                                   const utf8_t *accept);
 
 // Find the last match of the utf8 codepoint chr in the utf8 string src.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak void *utf8rchr(const void *src, int chr);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak utf8_t *utf8rchr(const utf8_t *src, int chr);
 
 // Number of bytes in the utf8 string str,
 // including the null terminating byte.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak size_t utf8size(const void *str);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak size_t utf8size(const utf8_t *str);
 
 // Similar to utf8size, except that the null terminating byte is excluded.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak size_t utf8size_lazy(const void *str);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak size_t utf8size_lazy(const utf8_t *str);
 
 // Similar to utf8size, except that only at most n bytes of src are looked and
 // the null terminating byte is excluded.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak size_t utf8nsize_lazy(const void *str, size_t n);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak size_t utf8nsize_lazy(const utf8_t *str, size_t n);
 
 // Number of utf8 codepoints in the utf8 string src that consists entirely
 // of utf8 codepoints from the utf8 string accept.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak size_t utf8spn(const void *src,
-                                                const void *accept);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak size_t utf8spn(const utf8_t *src,
+                                                                 const utf8_t *accept);
 
 // The position of the utf8 string needle in the utf8 string haystack.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak void *utf8str(const void *haystack,
-                                               const void *needle);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak utf8_t *utf8str(const utf8_t *haystack,
+                                                                  const utf8_t *needle);
 
 // The position of the utf8 string needle in the utf8 string haystack, case
 // insensitive.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak void *utf8casestr(const void *haystack,
-                                                   const void *needle);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak utf8_t *utf8casestr(const utf8_t *haystack,
+                                                                      const utf8_t *needle);
 
 // Return 0 on success, or the position of the invalid
 // utf8 codepoint on failure.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak void *utf8valid(const void *str);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak utf8_t *utf8valid(const utf8_t *str);
 
 // Similar to utf8valid, except that only at most n bytes of src are looked.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak void *utf8nvalid(const void *str, size_t n);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak utf8_t *utf8nvalid(const utf8_t *str, size_t n);
 
 // Given a null-terminated string, makes the string valid by replacing invalid
 // codepoints with a 1-byte replacement. Returns 0 on success.
-utf8_nonnull utf8_weak int utf8makevalid(void *str,
+utf8_nonnull utf8_weak int utf8makevalid(utf8_t *str,
                                          const utf8_int32_t replacement);
 
 // Sets out_codepoint to the current utf8 codepoint in str, and returns the
 // address of the next utf8 codepoint after the current one in str.
-utf8_constexpr14 utf8_nonnull utf8_weak void *
-utf8codepoint(const void *utf8_restrict str,
+utf8_constexpr14 utf8_nonnull utf8_weak utf8_t *
+utf8codepoint(const utf8_t *utf8_restrict str,
               utf8_int32_t *utf8_restrict out_codepoint);
 
 // Calculates the size of the next utf8 codepoint in str.
-utf8_constexpr14 utf8_nonnull utf8_weak size_t utf8codepointcalcsize(const void *str);
+utf8_constexpr14 utf8_nonnull utf8_weak size_t utf8codepointcalcsize(const utf8_t *str);
 
 // Returns the size of the given codepoint in bytes.
 utf8_constexpr14 utf8_weak size_t utf8codepointsize(utf8_int32_t chr);
@@ -225,8 +234,8 @@ utf8_constexpr14 utf8_weak size_t utf8codepointsize(utf8_int32_t chr);
 // place after the written codepoint. Pass how many bytes left in the buffer to
 // n. If there is not enough space for the codepoint, this function returns
 // null.
-utf8_nonnull utf8_weak void *utf8catcodepoint(void *str, utf8_int32_t chr,
-                                              size_t n);
+utf8_nonnull utf8_weak utf8_t *utf8catcodepoint(utf8_t *str, utf8_int32_t chr,
+                                                size_t n);
 
 // Returns 1 if the given character is lowercase, or 0 if it is not.
 utf8_constexpr14 utf8_weak int utf8islower(utf8_int32_t chr);
@@ -235,10 +244,10 @@ utf8_constexpr14 utf8_weak int utf8islower(utf8_int32_t chr);
 utf8_constexpr14 utf8_weak int utf8isupper(utf8_int32_t chr);
 
 // Transform the given string into all lowercase codepoints.
-utf8_nonnull utf8_weak void utf8lwr(void *utf8_restrict str);
+utf8_nonnull utf8_weak void utf8lwr(utf8_t *utf8_restrict str);
 
 // Transform the given string into all uppercase codepoints.
-utf8_nonnull utf8_weak void utf8upr(void *utf8_restrict str);
+utf8_nonnull utf8_weak void utf8upr(utf8_t *utf8_restrict str);
 
 // Make a codepoint lower case if possible.
 utf8_constexpr14 utf8_weak utf8_int32_t utf8lwrcodepoint(utf8_int32_t cp);
@@ -248,30 +257,30 @@ utf8_constexpr14 utf8_weak utf8_int32_t utf8uprcodepoint(utf8_int32_t cp);
 
 // Sets out_codepoint to the current utf8 codepoint in str, and returns the
 // address of the previous utf8 codepoint before the current one in str.
-utf8_constexpr14 utf8_nonnull utf8_weak void *
-utf8rcodepoint(const void *utf8_restrict str,
+utf8_constexpr14 utf8_nonnull utf8_weak utf8_t *
+utf8rcodepoint(const utf8_t *utf8_restrict str,
                utf8_int32_t *utf8_restrict out_codepoint);
 
 // Duplicate the utf8 string src by getting its size, calling alloc_func_ptr to
 // copy over data to a new buffer, and returning that. Or 0 if alloc_func_ptr
 // returned null.
-utf8_weak void *utf8dup_ex(const void *src,
-                           void *(*alloc_func_ptr)(void *, size_t),
-                           void *user_data);
+utf8_weak utf8_t *utf8dup_ex(const utf8_t *src,
+                             utf8_t *(*alloc_func_ptr)(utf8_t *, size_t),
+                             utf8_t *user_data);
 
 // Similar to utf8dup, except that at most n bytes of src are copied. If src is
 // longer than n, only n bytes are copied and a null byte is added.
 //
 // Returns a new string if successful, 0 otherwise.
-utf8_weak void *utf8ndup_ex(const void *src, size_t n,
-                            void *(*alloc_func_ptr)(void *, size_t),
-                            void *user_data);
+utf8_weak utf8_t *utf8ndup_ex(const utf8_t *src, size_t n,
+                              utf8_t *(*alloc_func_ptr)(utf8_t *, size_t),
+                              utf8_t *user_data);
 
 #undef utf8_weak
 #undef utf8_pure
 #undef utf8_nonnull
 
-utf8_constexpr14 int utf8casecmp(const void *src1, const void *src2) {
+utf8_constexpr14 int utf8casecmp(const utf8_t *src1, const utf8_t *src2) {
   utf8_int32_t src1_lwr_cp = 0, src2_lwr_cp = 0, src1_upr_cp = 0,
         src2_upr_cp = 0, src1_orig_cp = 0, src2_orig_cp = 0;
 
@@ -299,7 +308,7 @@ utf8_constexpr14 int utf8casecmp(const void *src1, const void *src2) {
   }
 }
 
-void *utf8cat(void *utf8_restrict dst, const void *utf8_restrict src) {
+utf8_t *utf8cat(utf8_t *utf8_restrict dst, const utf8_t *utf8_restrict src) {
   char *d = (char *)dst;
   const char *s = (const char *)src;
 
@@ -319,7 +328,7 @@ void *utf8cat(void *utf8_restrict dst, const void *utf8_restrict src) {
   return dst;
 }
 
-utf8_constexpr14 void *utf8chr(const void *src, utf8_int32_t chr) {
+utf8_constexpr14 utf8_t *utf8chr(const utf8_t *src, utf8_int32_t chr) {
   char c[5] = {'\0', '\0', '\0', '\0', '\0'};
 
   if (0 == chr) {
@@ -329,7 +338,7 @@ utf8_constexpr14 void *utf8chr(const void *src, utf8_int32_t chr) {
     while ('\0' != *s) {
       s++;
     }
-    return (void *)s;
+    return (utf8_t *)s;
   } else if (0 == ((utf8_int32_t)0xffffff80 & chr)) {
     // 1-byte/7-bit ascii
     // (0b0xxxxxxx)
@@ -360,7 +369,7 @@ utf8_constexpr14 void *utf8chr(const void *src, utf8_int32_t chr) {
   return utf8str(src, c);
 }
 
-utf8_constexpr14 int utf8cmp(const void *src1, const void *src2) {
+utf8_constexpr14 int utf8cmp(const utf8_t *src1, const utf8_t *src2) {
   const unsigned char *s1 = (const unsigned char *)src1;
   const unsigned char *s2 = (const unsigned char *)src2;
 
@@ -379,9 +388,9 @@ utf8_constexpr14 int utf8cmp(const void *src1, const void *src2) {
   return 0;
 }
 
-utf8_constexpr14 int utf8coll(const void *src1, const void *src2);
+utf8_constexpr14 int utf8coll(const utf8_t *src1, const utf8_t *src2);
 
-void *utf8cpy(void *utf8_restrict dst, const void *utf8_restrict src) {
+utf8_t *utf8cpy(utf8_t *utf8_restrict dst, const utf8_t *utf8_restrict src) {
   char *d = (char *)dst;
   const char *s = (const char *)src;
 
@@ -397,7 +406,7 @@ void *utf8cpy(void *utf8_restrict dst, const void *utf8_restrict src) {
   return dst;
 }
 
-utf8_constexpr14 size_t utf8cspn(const void *src, const void *reject) {
+utf8_constexpr14 size_t utf8cspn(const utf8_t *src, const utf8_t *reject) {
   const char *s = (const char *)src;
   size_t chars = 0;
 
@@ -448,10 +457,10 @@ utf8_constexpr14 size_t utf8cspn(const void *src, const void *reject) {
   return chars;
 }
 
-void *utf8dup(const void *src) { return utf8dup_ex(src, utf8_null, utf8_null); }
+utf8_t *utf8dup(const utf8_t *src) { return utf8dup_ex(src, utf8_null, utf8_null); }
 
-void *utf8dup_ex(const void *src, void *(*alloc_func_ptr)(void *, size_t),
-                                  void *user_data) {
+utf8_t *utf8dup_ex(const utf8_t *src, utf8_t *(*alloc_func_ptr)(utf8_t *, size_t),
+                                  utf8_t *user_data) {
   const char *s = (const char *)src;
   char *n = utf8_null;
 
@@ -482,13 +491,13 @@ void *utf8dup_ex(const void *src, void *(*alloc_func_ptr)(void *, size_t),
   }
 }
 
-utf8_constexpr14 void *utf8fry(const void *str);
+utf8_constexpr14 utf8_t *utf8fry(const utf8_t *str);
 
-utf8_constexpr14 size_t utf8len(const void *str) {
+utf8_constexpr14 size_t utf8len(const utf8_t *str) {
   return utf8nlen(str, SIZE_MAX);
 }
 
-utf8_constexpr14 size_t utf8nlen(const void *str, size_t n) {
+utf8_constexpr14 size_t utf8nlen(const utf8_t *str, size_t n) {
   const unsigned char *s = (const unsigned char *)str;
   const unsigned char *t = s;
   size_t length = 0;
@@ -519,7 +528,7 @@ utf8_constexpr14 size_t utf8nlen(const void *str, size_t n) {
   return length;
 }
 
-utf8_constexpr14 int utf8ncasecmp(const void *src1, const void *src2, size_t n) {
+utf8_constexpr14 int utf8ncasecmp(const utf8_t *src1, const utf8_t *src2, size_t n) {
   utf8_int32_t src1_lwr_cp = 0, src2_lwr_cp = 0, src1_upr_cp = 0, src2_upr_cp = 0,
         src1_orig_cp = 0, src2_orig_cp = 0;
 
@@ -591,7 +600,7 @@ utf8_constexpr14 int utf8ncasecmp(const void *src1, const void *src2, size_t n) 
   return 0;
 }
 
-void *utf8ncat(void *utf8_restrict dst, const void *utf8_restrict src,
+utf8_t *utf8ncat(utf8_t *utf8_restrict dst, const utf8_t *utf8_restrict src,
                size_t n) {
   char *d = (char *)dst;
   const char *s = (const char *)src;
@@ -613,7 +622,7 @@ void *utf8ncat(void *utf8_restrict dst, const void *utf8_restrict src,
   return dst;
 }
 
-utf8_constexpr14 int utf8ncmp(const void *src1, const void *src2, size_t n) {
+utf8_constexpr14 int utf8ncmp(const utf8_t *src1, const utf8_t *src2, size_t n) {
   const unsigned char *s1 = (const unsigned char *)src1;
   const unsigned char *s2 = (const unsigned char *)src2;
 
@@ -632,7 +641,7 @@ utf8_constexpr14 int utf8ncmp(const void *src1, const void *src2, size_t n) {
   return 0;
 }
 
-void *utf8ncpy(void *utf8_restrict dst, const void *utf8_restrict src,
+utf8_t *utf8ncpy(utf8_t *utf8_restrict dst, const utf8_t *utf8_restrict src,
                size_t n) {
   char *d = (char *)dst;
   const char *s = (const char *)src;
@@ -667,12 +676,12 @@ void *utf8ncpy(void *utf8_restrict dst, const void *utf8_restrict src,
   return dst;
 }
 
-void *utf8ndup(const void *src, size_t n) {
+utf8_t *utf8ndup(const utf8_t *src, size_t n) {
   return utf8ndup_ex(src, n, utf8_null, utf8_null);
 }
 
-void *utf8ndup_ex(const void *src, size_t n,
-                  void *(*alloc_func_ptr)(void *, size_t), void *user_data) {
+utf8_t *utf8ndup_ex(const utf8_t *src, size_t n,
+                  utf8_t *(*alloc_func_ptr)(utf8_t *, size_t), utf8_t *user_data) {
   const char *s = (const char *)src;
   char *c = utf8_null;
   size_t bytes = 0;
@@ -710,7 +719,7 @@ void *utf8ndup_ex(const void *src, size_t n,
   return c;
 }
 
-utf8_constexpr14 void *utf8rchr(const void *src, int chr) {
+utf8_constexpr14 utf8_t *utf8rchr(const utf8_t *src, int chr) {
   const char *s = (const char *)src;
   const char *match = utf8_null;
   char c[5] = {'\0', '\0', '\0', '\0', '\0'};
@@ -721,7 +730,7 @@ utf8_constexpr14 void *utf8rchr(const void *src, int chr) {
     while ('\0' != *s) {
       s++;
     }
-    return (void *)s;
+    return (utf8_t *)s;
   } else if (0 == ((int)0xffffff80 & chr)) {
     // 1-byte/7-bit ascii
     // (0b0xxxxxxx)
@@ -775,10 +784,10 @@ utf8_constexpr14 void *utf8rchr(const void *src, int chr) {
   }
 
   // return the last match we found (or 0 if no match was found)
-  return (void *)match;
+  return (utf8_t *)match;
 }
 
-utf8_constexpr14 void *utf8pbrk(const void *str, const void *accept) {
+utf8_constexpr14 utf8_t *utf8pbrk(const utf8_t *str, const utf8_t *accept) {
   const char *s = (const char *)str;
 
   while ('\0' != *s) {
@@ -790,7 +799,7 @@ utf8_constexpr14 void *utf8pbrk(const void *str, const void *accept) {
       // (it is not 0b10xxxxxx) and we have successfully matched
       // a previous character (0 < offset) - we found a match
       if ((0x80 != (0xc0 & *a)) && (0 < offset)) {
-        return (void *)s;
+        return (utf8_t *)s;
       } else {
         if (*a == s[offset]) {
           // part of a utf8 codepoint matched, so move our checking
@@ -813,7 +822,7 @@ utf8_constexpr14 void *utf8pbrk(const void *str, const void *accept) {
 
     // we found a match on the last utf8 codepoint
     if (0 < offset) {
-      return (void *)s;
+      return (utf8_t *)s;
     }
 
     // the current utf8 codepoint in src did not match accept, but src
@@ -827,15 +836,15 @@ utf8_constexpr14 void *utf8pbrk(const void *str, const void *accept) {
   return utf8_null;
 }
 
-utf8_constexpr14 size_t utf8size(const void *str) {
+utf8_constexpr14 size_t utf8size(const utf8_t *str) {
   return utf8size_lazy(str) + 1;
 }
 
-utf8_constexpr14 size_t utf8size_lazy(const void *str) {
+utf8_constexpr14 size_t utf8size_lazy(const utf8_t *str) {
   return utf8nsize_lazy(str, SIZE_MAX);
 }
 
-utf8_constexpr14 size_t utf8nsize_lazy(const void *str, size_t n) {
+utf8_constexpr14 size_t utf8nsize_lazy(const utf8_t *str, size_t n) {
   const char *s = (const char *)str;
   size_t size = 0;
   while (size < n && '\0' != s[size]) {
@@ -844,7 +853,7 @@ utf8_constexpr14 size_t utf8nsize_lazy(const void *str, size_t n) {
   return size;
 }
 
-utf8_constexpr14 size_t utf8spn(const void *src, const void *accept) {
+utf8_constexpr14 size_t utf8spn(const utf8_t *src, const utf8_t *accept) {
   const char *s = (const char *)src;
   size_t chars = 0;
 
@@ -898,14 +907,14 @@ utf8_constexpr14 size_t utf8spn(const void *src, const void *accept) {
   return chars;
 }
 
-utf8_constexpr14 void *utf8str(const void *haystack, const void *needle) {
+utf8_constexpr14 utf8_t *utf8str(const utf8_t *haystack, const utf8_t *needle) {
   const char *h = (const char *)haystack;
   utf8_int32_t throwaway_codepoint = 0;
 
   // if needle has no utf8 codepoints before the null terminating
   // byte then return haystack
   if ('\0' == *((const char *)needle)) {
-    return (void *)haystack;
+    return (utf8_t *)haystack;
   }
 
   while ('\0' != *h) {
@@ -920,7 +929,7 @@ utf8_constexpr14 void *utf8str(const void *haystack, const void *needle) {
     if ('\0' == *n) {
       // we found the whole utf8 string for needle in haystack at
       // maybeMatch, so return it
-      return (void *)maybeMatch;
+      return (utf8_t *)maybeMatch;
     } else {
       // h could be in the middle of an unmatching utf8 codepoint,
       // so we need to march it on to the next character beginning
@@ -933,22 +942,22 @@ utf8_constexpr14 void *utf8str(const void *haystack, const void *needle) {
   return utf8_null;
 }
 
-utf8_constexpr14 void *utf8casestr(const void *haystack, const void *needle) {
-  const void *h = haystack;
+utf8_constexpr14 utf8_t *utf8casestr(const utf8_t *haystack, const utf8_t *needle) {
+  const utf8_t *h = haystack;
 
   // if needle has no utf8 codepoints before the null terminating
   // byte then return haystack
   if ('\0' == *((const char *)needle)) {
-    return (void *)haystack;
+    return (utf8_t *)haystack;
   }
 
   for (;;) {
-    const void *maybeMatch = h;
-    const void *n = needle;
+    const utf8_t *maybeMatch = h;
+    const utf8_t *n = needle;
     utf8_int32_t h_cp = 0, n_cp = 0;
 
     // Get the next code point and track it
-    const void *nextH = h = utf8codepoint(h, &h_cp);
+    const utf8_t *nextH = h = utf8codepoint(h, &h_cp);
     n = utf8codepoint(n, &n_cp);
 
     while ((0 != h_cp) && (0 != n_cp)) {
@@ -967,7 +976,7 @@ utf8_constexpr14 void *utf8casestr(const void *haystack, const void *needle) {
     if (0 == n_cp) {
       // we found the whole utf8 string for needle in haystack at
       // maybeMatch, so return it
-      return (void *)maybeMatch;
+      return (utf8_t *)maybeMatch;
     }
 
     if (0 == h_cp) {
@@ -980,11 +989,11 @@ utf8_constexpr14 void *utf8casestr(const void *haystack, const void *needle) {
   }
 }
 
-utf8_constexpr14 void *utf8valid(const void *str) {
+utf8_constexpr14 utf8_t *utf8valid(const utf8_t *str) {
   return utf8nvalid(str, SIZE_MAX);
 }
 
-utf8_constexpr14 void *utf8nvalid(const void *str, size_t n) {
+utf8_constexpr14 utf8_t *utf8nvalid(const utf8_t *str, size_t n) {
   const char *s = (const char *)str;
   const char *t = s;
   size_t consumed = 0, remained = 0;
@@ -995,26 +1004,26 @@ utf8_constexpr14 void *utf8nvalid(const void *str, size_t n) {
     if (0xf0 == (0xf8 & *s)) {
       // ensure that there's 4 bytes or more remained
       if (remained < 4) {
-        return (void *)s;
+        return (utf8_t *)s;
       }
 
       // ensure each of the 3 following bytes in this 4-byte
       // utf8 codepoint began with 0b10xxxxxx
       if ((0x80 != (0xc0 & s[1])) || (0x80 != (0xc0 & s[2])) ||
           (0x80 != (0xc0 & s[3]))) {
-        return (void *)s;
+        return (utf8_t *)s;
       }
 
       // ensure that our utf8 codepoint ended after 4 bytes
       if (0x80 == (0xc0 & s[4])) {
-        return (void *)s;
+        return (utf8_t *)s;
       }
 
       // ensure that the top 5 bits of this 4-byte utf8
       // codepoint were not 0, as then we could have used
       // one of the smaller encodings
       if ((0 == (0x07 & s[0])) && (0 == (0x30 & s[1]))) {
-        return (void *)s;
+        return (utf8_t *)s;
       }
 
       // 4-byte utf8 code point (began with 0b11110xxx)
@@ -1022,25 +1031,25 @@ utf8_constexpr14 void *utf8nvalid(const void *str, size_t n) {
     } else if (0xe0 == (0xf0 & *s)) {
       // ensure that there's 3 bytes or more remained
       if (remained < 3) {
-        return (void *)s;
+        return (utf8_t *)s;
       }
 
       // ensure each of the 2 following bytes in this 3-byte
       // utf8 codepoint began with 0b10xxxxxx
       if ((0x80 != (0xc0 & s[1])) || (0x80 != (0xc0 & s[2]))) {
-        return (void *)s;
+        return (utf8_t *)s;
       }
 
       // ensure that our utf8 codepoint ended after 3 bytes
       if (0x80 == (0xc0 & s[3])) {
-        return (void *)s;
+        return (utf8_t *)s;
       }
 
       // ensure that the top 5 bits of this 3-byte utf8
       // codepoint were not 0, as then we could have used
       // one of the smaller encodings
       if ((0 == (0x0f & s[0])) && (0 == (0x20 & s[1]))) {
-        return (void *)s;
+        return (utf8_t *)s;
       }
 
       // 3-byte utf8 code point (began with 0b1110xxxx)
@@ -1048,25 +1057,25 @@ utf8_constexpr14 void *utf8nvalid(const void *str, size_t n) {
     } else if (0xc0 == (0xe0 & *s)) {
       // ensure that there's 2 bytes or more remained
       if (remained < 2) {
-        return (void *)s;
+        return (utf8_t *)s;
       }
 
       // ensure the 1 following byte in this 2-byte
       // utf8 codepoint began with 0b10xxxxxx
       if (0x80 != (0xc0 & s[1])) {
-        return (void *)s;
+        return (utf8_t *)s;
       }
 
       // ensure that our utf8 codepoint ended after 2 bytes
       if (0x80 == (0xc0 & s[2])) {
-        return (void *)s;
+        return (utf8_t *)s;
       }
 
       // ensure that the top 4 bits of this 2-byte utf8
       // codepoint were not 0, as then we could have used
       // one of the smaller encodings
       if (0 == (0x1e & s[0])) {
-        return (void *)s;
+        return (utf8_t *)s;
       }
 
       // 2-byte utf8 code point (began with 0b110xxxxx)
@@ -1076,14 +1085,14 @@ utf8_constexpr14 void *utf8nvalid(const void *str, size_t n) {
       s += 1;
     } else {
       // we have an invalid 0b1xxxxxxx utf8 code point entry
-      return (void *)s;
+      return (utf8_t *)s;
     }
   }
 
   return utf8_null;
 }
 
-int utf8makevalid(void *str, const utf8_int32_t replacement) {
+int utf8makevalid(utf8_t *str, const utf8_int32_t replacement) {
   char *read = (char *)str;
   char *write = read;
   const char r = (char)replacement;
@@ -1148,7 +1157,7 @@ int utf8makevalid(void *str, const utf8_int32_t replacement) {
   return 0;
 }
 
-utf8_constexpr14 void *utf8codepoint(const void *utf8_restrict str,
+utf8_constexpr14 utf8_t *utf8codepoint(const utf8_t *utf8_restrict str,
                                      utf8_int32_t *utf8_restrict out_codepoint) {
   const char *s = (const char *)str;
 
@@ -1172,10 +1181,10 @@ utf8_constexpr14 void *utf8codepoint(const void *utf8_restrict str,
     s += 1;
   }
 
-  return (void *)s;
+  return (utf8_t *)s;
 }
 
-utf8_constexpr14 size_t utf8codepointcalcsize(const void *str) {
+utf8_constexpr14 size_t utf8codepointcalcsize(const utf8_t *str) {
   const char *s = (const char *)str;
 
   if (0xf0 == (0xf8 & s[0])) {
@@ -1205,7 +1214,7 @@ utf8_constexpr14 size_t utf8codepointsize(utf8_int32_t chr) {
   }
 }
 
-void *utf8catcodepoint(void *str, utf8_int32_t chr, size_t n) {
+utf8_t *utf8catcodepoint(utf8_t *str, utf8_int32_t chr, size_t n) {
   char *s = (char *)str;
 
   if (0 == ((utf8_int32_t)0xffffff80 & chr)) {
@@ -1255,8 +1264,8 @@ utf8_constexpr14 int utf8islower(utf8_int32_t chr) { return chr != utf8uprcodepo
 
 utf8_constexpr14 int utf8isupper(utf8_int32_t chr) { return chr != utf8lwrcodepoint(chr); }
 
-void utf8lwr(void *utf8_restrict str) {
-  void *p = utf8_null, *pn = utf8_null;
+void utf8lwr(utf8_t *utf8_restrict str) {
+  utf8_t *p = utf8_null, *pn = utf8_null;
   utf8_int32_t cp = 0;
 
   p = (char *)str;
@@ -1275,8 +1284,8 @@ void utf8lwr(void *utf8_restrict str) {
   }
 }
 
-void utf8upr(void *utf8_restrict str) {
-  void *p = utf8_null, *pn = utf8_null;
+void utf8upr(utf8_t *utf8_restrict str) {
+  utf8_t *p = utf8_null, *pn = utf8_null;
   utf8_int32_t cp = 0;
 
   p = (char *)str;
@@ -1627,7 +1636,7 @@ utf8_constexpr14 utf8_int32_t utf8uprcodepoint(utf8_int32_t cp) {
   return cp;
 }
 
-utf8_constexpr14 void *utf8rcodepoint(const void *utf8_restrict str,
+utf8_constexpr14 utf8_t *utf8rcodepoint(const utf8_t *utf8_restrict str,
                      utf8_int32_t *utf8_restrict out_codepoint) {
   const char *s = (const char *)str;
 
@@ -1651,7 +1660,7 @@ utf8_constexpr14 void *utf8rcodepoint(const void *utf8_restrict str,
     s--;
   } while ((0 != (0x80 & s[0])) && (0x80 == (0xc0 & s[0])));
 
-  return (void *)s;
+  return (utf8_t *)s;
 }
 
 #undef utf8_restrict

--- a/utf8.h
+++ b/utf8.h
@@ -705,7 +705,7 @@ utf8_int8_t *utf8ndup_ex(const utf8_int8_t *src, size_t n,
 
 utf8_constexpr14_impl utf8_int8_t *utf8rchr(const utf8_int8_t *src, int chr) {
 
-  const utf8_int8_t *match = utf8_null;
+  utf8_int8_t *match = utf8_null;
   utf8_int8_t c[5] = {'\0', '\0', '\0', '\0', '\0'};
 
   if (0 == chr) {
@@ -752,7 +752,7 @@ utf8_constexpr14_impl utf8_int8_t *utf8rchr(const utf8_int8_t *src, int chr) {
 
     if ('\0' == c[offset]) {
       // we found a matching utf8 code point
-      match = src;
+      match = (utf8_int8_t *)src;
       src += offset;
     } else {
       src += offset;
@@ -768,7 +768,7 @@ utf8_constexpr14_impl utf8_int8_t *utf8rchr(const utf8_int8_t *src, int chr) {
   }
 
   // return the last match we found (or 0 if no match was found)
-  return (utf8_int8_t *)match;
+  return match;
 }
 
 utf8_constexpr14_impl utf8_int8_t *utf8pbrk(const utf8_int8_t *str, const utf8_int8_t *accept) {

--- a/utf8.h
+++ b/utf8.h
@@ -89,8 +89,11 @@ extern "C" {
 
 #if defined(__cplusplus) && __cplusplus >= 201402L
 #define utf8_constexpr14 constexpr
+#define utf8_constexpr14_impl constexpr
 #else
-#define utf8_constexpr14
+// constexpr and weak are incompatible. so only enable one of them
+#define utf8_constexpr14 utf8_weak
+#define utf8_constexpr14_impl
 #endif
 
 #if defined(__cplusplus) && __cplusplus >= 202002L
@@ -101,20 +104,20 @@ typedef char utf8_int8_t;
 
 // Return less than 0, 0, greater than 0 if src1 < src2, src1 == src2, src1 >
 // src2 respectively, case insensitive.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak int utf8casecmp(const utf8_int8_t *src1,
-                                                                  const utf8_int8_t *src2);
+utf8_constexpr14 utf8_nonnull utf8_pure int utf8casecmp(const utf8_int8_t *src1,
+                                                        const utf8_int8_t *src2);
 
 // Append the utf8 string src onto the utf8 string dst.
 utf8_nonnull utf8_weak utf8_int8_t *utf8cat(utf8_int8_t *utf8_restrict dst,
                                        const utf8_int8_t *utf8_restrict src);
 
 // Find the first match of the utf8 codepoint chr in the utf8 string src.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak utf8_int8_t *utf8chr(const utf8_int8_t *src,
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_int8_t *utf8chr(const utf8_int8_t *src,
                                                                   utf8_int32_t chr);
 
 // Return less than 0, 0, greater than 0 if src1 < src2,
 // src1 == src2, src1 > src2 respectively.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak int utf8cmp(const utf8_int8_t *src1,
+utf8_constexpr14 utf8_nonnull utf8_pure int utf8cmp(const utf8_int8_t *src1,
                                                               const utf8_int8_t *src2);
 
 // Copy the utf8 string src onto the memory allocated in dst.
@@ -123,7 +126,7 @@ utf8_nonnull utf8_weak utf8_int8_t *utf8cpy(utf8_int8_t *utf8_restrict dst,
 
 // Number of utf8 codepoints in the utf8 string src that consists entirely
 // of utf8 codepoints not from the utf8 string reject.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak size_t utf8cspn(const utf8_int8_t *src,
+utf8_constexpr14 utf8_nonnull utf8_pure size_t utf8cspn(const utf8_int8_t *src,
                                                                   const utf8_int8_t *reject);
 
 // Duplicate the utf8 string src by getting its size, malloc'ing a new buffer
@@ -132,15 +135,15 @@ utf8_weak utf8_int8_t *utf8dup(const utf8_int8_t *src);
 
 // Number of utf8 codepoints in the utf8 string str,
 // excluding the null terminating byte.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak size_t utf8len(const utf8_int8_t *str);
+utf8_constexpr14 utf8_nonnull utf8_pure size_t utf8len(const utf8_int8_t *str);
 
 // Similar to utf8len, except that only at most n bytes of src are looked.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak size_t utf8nlen(const utf8_int8_t *str, size_t n);
+utf8_constexpr14 utf8_nonnull utf8_pure size_t utf8nlen(const utf8_int8_t *str, size_t n);
 
 // Return less than 0, 0, greater than 0 if src1 < src2, src1 == src2, src1 >
 // src2 respectively, case insensitive. Checking at most n bytes of each utf8
 // string.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak int utf8ncasecmp(const utf8_int8_t *src1,
+utf8_constexpr14 utf8_nonnull utf8_pure int utf8ncasecmp(const utf8_int8_t *src1,
                                                                    const utf8_int8_t *src2, size_t n);
 
 // Append the utf8 string src onto the utf8 string dst,
@@ -152,7 +155,7 @@ utf8_nonnull utf8_weak utf8_int8_t *utf8ncat(utf8_int8_t *utf8_restrict dst,
 // Return less than 0, 0, greater than 0 if src1 < src2,
 // src1 == src2, src1 > src2 respectively. Checking at most n
 // bytes of each utf8 string.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak int utf8ncmp(const utf8_int8_t *src1,
+utf8_constexpr14 utf8_nonnull utf8_pure int utf8ncmp(const utf8_int8_t *src1,
                                                                const utf8_int8_t *src2, size_t n);
 
 // Copy the utf8 string src onto the memory allocated in dst.
@@ -172,43 +175,43 @@ utf8_weak utf8_int8_t *utf8ndup(const utf8_int8_t *src, size_t n);
 
 // Locates the first occurrence in the utf8 string str of any byte in the
 // utf8 string accept, or 0 if no match was found.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak utf8_int8_t *utf8pbrk(const utf8_int8_t *str,
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_int8_t *utf8pbrk(const utf8_int8_t *str,
                                                                    const utf8_int8_t *accept);
 
 // Find the last match of the utf8 codepoint chr in the utf8 string src.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak utf8_int8_t *utf8rchr(const utf8_int8_t *src, int chr);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_int8_t *utf8rchr(const utf8_int8_t *src, int chr);
 
 // Number of bytes in the utf8 string str,
 // including the null terminating byte.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak size_t utf8size(const utf8_int8_t *str);
+utf8_constexpr14 utf8_nonnull utf8_pure size_t utf8size(const utf8_int8_t *str);
 
 // Similar to utf8size, except that the null terminating byte is excluded.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak size_t utf8size_lazy(const utf8_int8_t *str);
+utf8_constexpr14 utf8_nonnull utf8_pure size_t utf8size_lazy(const utf8_int8_t *str);
 
 // Similar to utf8size, except that only at most n bytes of src are looked and
 // the null terminating byte is excluded.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak size_t utf8nsize_lazy(const utf8_int8_t *str, size_t n);
+utf8_constexpr14 utf8_nonnull utf8_pure size_t utf8nsize_lazy(const utf8_int8_t *str, size_t n);
 
 // Number of utf8 codepoints in the utf8 string src that consists entirely
 // of utf8 codepoints from the utf8 string accept.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak size_t utf8spn(const utf8_int8_t *src,
+utf8_constexpr14 utf8_nonnull utf8_pure size_t utf8spn(const utf8_int8_t *src,
                                                                  const utf8_int8_t *accept);
 
 // The position of the utf8 string needle in the utf8 string haystack.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak utf8_int8_t *utf8str(const utf8_int8_t *haystack,
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_int8_t *utf8str(const utf8_int8_t *haystack,
                                                                   const utf8_int8_t *needle);
 
 // The position of the utf8 string needle in the utf8 string haystack, case
 // insensitive.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak utf8_int8_t *utf8casestr(const utf8_int8_t *haystack,
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_int8_t *utf8casestr(const utf8_int8_t *haystack,
                                                                       const utf8_int8_t *needle);
 
 // Return 0 on success, or the position of the invalid
 // utf8 codepoint on failure.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak utf8_int8_t *utf8valid(const utf8_int8_t *str);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_int8_t *utf8valid(const utf8_int8_t *str);
 
 // Similar to utf8valid, except that only at most n bytes of src are looked.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak utf8_int8_t *utf8nvalid(const utf8_int8_t *str, size_t n);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_int8_t *utf8nvalid(const utf8_int8_t *str, size_t n);
 
 // Given a null-terminated string, makes the string valid by replacing invalid
 // codepoints with a 1-byte replacement. Returns 0 on success.
@@ -217,15 +220,15 @@ utf8_nonnull utf8_weak int utf8makevalid(utf8_int8_t *str,
 
 // Sets out_codepoint to the current utf8 codepoint in str, and returns the
 // address of the next utf8 codepoint after the current one in str.
-utf8_constexpr14 utf8_nonnull utf8_weak utf8_int8_t *
+utf8_constexpr14 utf8_nonnull utf8_int8_t *
 utf8codepoint(const utf8_int8_t *utf8_restrict str,
               utf8_int32_t *utf8_restrict out_codepoint);
 
 // Calculates the size of the next utf8 codepoint in str.
-utf8_constexpr14 utf8_nonnull utf8_weak size_t utf8codepointcalcsize(const utf8_int8_t *str);
+utf8_constexpr14 utf8_nonnull size_t utf8codepointcalcsize(const utf8_int8_t *str);
 
 // Returns the size of the given codepoint in bytes.
-utf8_constexpr14 utf8_weak size_t utf8codepointsize(utf8_int32_t chr);
+utf8_constexpr14 size_t utf8codepointsize(utf8_int32_t chr);
 
 // Write a codepoint to the given string, and return the address to the next
 // place after the written codepoint. Pass how many bytes left in the buffer to
@@ -235,10 +238,10 @@ utf8_nonnull utf8_weak utf8_int8_t *utf8catcodepoint(utf8_int8_t *str, utf8_int3
                                                 size_t n);
 
 // Returns 1 if the given character is lowercase, or 0 if it is not.
-utf8_constexpr14 utf8_weak int utf8islower(utf8_int32_t chr);
+utf8_constexpr14 int utf8islower(utf8_int32_t chr);
 
 // Returns 1 if the given character is uppercase, or 0 if it is not.
-utf8_constexpr14 utf8_weak int utf8isupper(utf8_int32_t chr);
+utf8_constexpr14 int utf8isupper(utf8_int32_t chr);
 
 // Transform the given string into all lowercase codepoints.
 utf8_nonnull utf8_weak void utf8lwr(utf8_int8_t *utf8_restrict str);
@@ -247,14 +250,14 @@ utf8_nonnull utf8_weak void utf8lwr(utf8_int8_t *utf8_restrict str);
 utf8_nonnull utf8_weak void utf8upr(utf8_int8_t *utf8_restrict str);
 
 // Make a codepoint lower case if possible.
-utf8_constexpr14 utf8_weak utf8_int32_t utf8lwrcodepoint(utf8_int32_t cp);
+utf8_constexpr14 utf8_int32_t utf8lwrcodepoint(utf8_int32_t cp);
 
 // Make a codepoint upper case if possible.
-utf8_constexpr14 utf8_weak utf8_int32_t utf8uprcodepoint(utf8_int32_t cp);
+utf8_constexpr14 utf8_int32_t utf8uprcodepoint(utf8_int32_t cp);
 
 // Sets out_codepoint to the current utf8 codepoint in str, and returns the
 // address of the previous utf8 codepoint before the current one in str.
-utf8_constexpr14 utf8_nonnull utf8_weak utf8_int8_t *
+utf8_constexpr14 utf8_nonnull utf8_int8_t *
 utf8rcodepoint(const utf8_int8_t *utf8_restrict str,
                utf8_int32_t *utf8_restrict out_codepoint);
 
@@ -277,7 +280,7 @@ utf8_weak utf8_int8_t *utf8ndup_ex(const utf8_int8_t *src, size_t n,
 #undef utf8_pure
 #undef utf8_nonnull
 
-utf8_constexpr14 int utf8casecmp(const utf8_int8_t *src1, const utf8_int8_t *src2) {
+utf8_constexpr14_impl int utf8casecmp(const utf8_int8_t *src1, const utf8_int8_t *src2) {
   utf8_int32_t src1_lwr_cp = 0, src2_lwr_cp = 0, src1_upr_cp = 0,
         src2_upr_cp = 0, src1_orig_cp = 0, src2_orig_cp = 0;
 
@@ -323,7 +326,7 @@ utf8_int8_t *utf8cat(utf8_int8_t *utf8_restrict dst, const utf8_int8_t *utf8_res
   return dst;
 }
 
-utf8_constexpr14 utf8_int8_t *utf8chr(const utf8_int8_t *src, utf8_int32_t chr) {
+utf8_constexpr14_impl utf8_int8_t *utf8chr(const utf8_int8_t *src, utf8_int32_t chr) {
   utf8_int8_t c[5] = {'\0', '\0', '\0', '\0', '\0'};
 
   if (0 == chr) {
@@ -363,7 +366,7 @@ utf8_constexpr14 utf8_int8_t *utf8chr(const utf8_int8_t *src, utf8_int32_t chr) 
   return utf8str(src, c);
 }
 
-utf8_constexpr14 int utf8cmp(const utf8_int8_t *src1, const utf8_int8_t *src2) {
+utf8_constexpr14_impl int utf8cmp(const utf8_int8_t *src1, const utf8_int8_t *src2) {
   while (('\0' != *src1) || ('\0' != *src2)) {
     if (*src1 < *src2) {
       return -1;
@@ -379,7 +382,7 @@ utf8_constexpr14 int utf8cmp(const utf8_int8_t *src1, const utf8_int8_t *src2) {
   return 0;
 }
 
-utf8_constexpr14 int utf8coll(const utf8_int8_t *src1, const utf8_int8_t *src2);
+utf8_constexpr14_impl int utf8coll(const utf8_int8_t *src1, const utf8_int8_t *src2);
 
 utf8_int8_t *utf8cpy(utf8_int8_t *utf8_restrict dst, const utf8_int8_t *utf8_restrict src) {
   utf8_int8_t *d = dst;
@@ -396,7 +399,7 @@ utf8_int8_t *utf8cpy(utf8_int8_t *utf8_restrict dst, const utf8_int8_t *utf8_res
   return dst;
 }
 
-utf8_constexpr14 size_t utf8cspn(const utf8_int8_t *src, const utf8_int8_t *reject) {
+utf8_constexpr14_impl size_t utf8cspn(const utf8_int8_t *src, const utf8_int8_t *reject) {
   size_t chars = 0;
 
   while ('\0' != *src) {
@@ -479,13 +482,13 @@ utf8_int8_t *utf8dup_ex(const utf8_int8_t *src, utf8_int8_t *(*alloc_func_ptr)(u
   }
 }
 
-utf8_constexpr14 utf8_int8_t *utf8fry(const utf8_int8_t *str);
+utf8_constexpr14_impl utf8_int8_t *utf8fry(const utf8_int8_t *str);
 
-utf8_constexpr14 size_t utf8len(const utf8_int8_t *str) {
+utf8_constexpr14_impl size_t utf8len(const utf8_int8_t *str) {
   return utf8nlen(str, SIZE_MAX);
 }
 
-utf8_constexpr14 size_t utf8nlen(const utf8_int8_t *str, size_t n) {
+utf8_constexpr14_impl size_t utf8nlen(const utf8_int8_t *str, size_t n) {
   const utf8_int8_t *t = str;
   size_t length = 0;
 
@@ -515,7 +518,7 @@ utf8_constexpr14 size_t utf8nlen(const utf8_int8_t *str, size_t n) {
   return length;
 }
 
-utf8_constexpr14 int utf8ncasecmp(const utf8_int8_t *src1, const utf8_int8_t *src2, size_t n) {
+utf8_constexpr14_impl int utf8ncasecmp(const utf8_int8_t *src1, const utf8_int8_t *src2, size_t n) {
   utf8_int32_t src1_lwr_cp = 0, src2_lwr_cp = 0, src1_upr_cp = 0, src2_upr_cp = 0,
         src1_orig_cp = 0, src2_orig_cp = 0;
 
@@ -608,7 +611,7 @@ utf8_int8_t *utf8ncat(utf8_int8_t *utf8_restrict dst, const utf8_int8_t *utf8_re
   return dst;
 }
 
-utf8_constexpr14 int utf8ncmp(const utf8_int8_t *src1, const utf8_int8_t *src2, size_t n) {
+utf8_constexpr14_impl int utf8ncmp(const utf8_int8_t *src1, const utf8_int8_t *src2, size_t n) {
   while ((0 != n--) && (('\0' != *src1) || ('\0' != *src2))) {
     if (*src1 < *src2) {
       return -1;
@@ -700,7 +703,7 @@ utf8_int8_t *utf8ndup_ex(const utf8_int8_t *src, size_t n,
   return c;
 }
 
-utf8_constexpr14 utf8_int8_t *utf8rchr(const utf8_int8_t *src, int chr) {
+utf8_constexpr14_impl utf8_int8_t *utf8rchr(const utf8_int8_t *src, int chr) {
 
   const utf8_int8_t *match = utf8_null;
   utf8_int8_t c[5] = {'\0', '\0', '\0', '\0', '\0'};
@@ -768,7 +771,7 @@ utf8_constexpr14 utf8_int8_t *utf8rchr(const utf8_int8_t *src, int chr) {
   return (utf8_int8_t *)match;
 }
 
-utf8_constexpr14 utf8_int8_t *utf8pbrk(const utf8_int8_t *str, const utf8_int8_t *accept) {
+utf8_constexpr14_impl utf8_int8_t *utf8pbrk(const utf8_int8_t *str, const utf8_int8_t *accept) {
   while ('\0' != *str) {
     const utf8_int8_t *a = accept;
     size_t offset = 0;
@@ -815,15 +818,15 @@ utf8_constexpr14 utf8_int8_t *utf8pbrk(const utf8_int8_t *str, const utf8_int8_t
   return utf8_null;
 }
 
-utf8_constexpr14 size_t utf8size(const utf8_int8_t *str) {
+utf8_constexpr14_impl size_t utf8size(const utf8_int8_t *str) {
   return utf8size_lazy(str) + 1;
 }
 
-utf8_constexpr14 size_t utf8size_lazy(const utf8_int8_t *str) {
+utf8_constexpr14_impl size_t utf8size_lazy(const utf8_int8_t *str) {
   return utf8nsize_lazy(str, SIZE_MAX);
 }
 
-utf8_constexpr14 size_t utf8nsize_lazy(const utf8_int8_t *str, size_t n) {
+utf8_constexpr14_impl size_t utf8nsize_lazy(const utf8_int8_t *str, size_t n) {
   size_t size = 0;
   while (size < n && '\0' != str[size]) {
     size++;
@@ -831,7 +834,7 @@ utf8_constexpr14 size_t utf8nsize_lazy(const utf8_int8_t *str, size_t n) {
   return size;
 }
 
-utf8_constexpr14 size_t utf8spn(const utf8_int8_t *src, const utf8_int8_t *accept) {
+utf8_constexpr14_impl size_t utf8spn(const utf8_int8_t *src, const utf8_int8_t *accept) {
   size_t chars = 0;
 
   while ('\0' != *src) {
@@ -884,7 +887,7 @@ utf8_constexpr14 size_t utf8spn(const utf8_int8_t *src, const utf8_int8_t *accep
   return chars;
 }
 
-utf8_constexpr14 utf8_int8_t *utf8str(const utf8_int8_t *haystack, const utf8_int8_t *needle) {
+utf8_constexpr14_impl utf8_int8_t *utf8str(const utf8_int8_t *haystack, const utf8_int8_t *needle) {
   utf8_int32_t throwaway_codepoint = 0;
 
   // if needle has no utf8 codepoints before the null terminating
@@ -918,7 +921,7 @@ utf8_constexpr14 utf8_int8_t *utf8str(const utf8_int8_t *haystack, const utf8_in
   return utf8_null;
 }
 
-utf8_constexpr14 utf8_int8_t *utf8casestr(const utf8_int8_t *haystack, const utf8_int8_t *needle) {
+utf8_constexpr14_impl utf8_int8_t *utf8casestr(const utf8_int8_t *haystack, const utf8_int8_t *needle) {
   // if needle has no utf8 codepoints before the null terminating
   // byte then return haystack
   if ('\0' == *needle) {
@@ -963,11 +966,11 @@ utf8_constexpr14 utf8_int8_t *utf8casestr(const utf8_int8_t *haystack, const utf
   }
 }
 
-utf8_constexpr14 utf8_int8_t *utf8valid(const utf8_int8_t *str) {
+utf8_constexpr14_impl utf8_int8_t *utf8valid(const utf8_int8_t *str) {
   return utf8nvalid(str, SIZE_MAX);
 }
 
-utf8_constexpr14 utf8_int8_t *utf8nvalid(const utf8_int8_t *str, size_t n) {
+utf8_constexpr14_impl utf8_int8_t *utf8nvalid(const utf8_int8_t *str, size_t n) {
   const utf8_int8_t *t = str;
   size_t consumed = 0, remained = 0;
 
@@ -1130,7 +1133,7 @@ int utf8makevalid(utf8_int8_t *str, const utf8_int32_t replacement) {
   return 0;
 }
 
-utf8_constexpr14 utf8_int8_t *utf8codepoint(const utf8_int8_t *utf8_restrict str,
+utf8_constexpr14_impl utf8_int8_t *utf8codepoint(const utf8_int8_t *utf8_restrict str,
                                      utf8_int32_t *utf8_restrict out_codepoint) {
   if (0xf0 == (0xf8 & str[0])) {
     // 4 byte utf8 codepoint
@@ -1155,7 +1158,7 @@ utf8_constexpr14 utf8_int8_t *utf8codepoint(const utf8_int8_t *utf8_restrict str
   return (utf8_int8_t *)str;
 }
 
-utf8_constexpr14 size_t utf8codepointcalcsize(const utf8_int8_t *str) {
+utf8_constexpr14_impl size_t utf8codepointcalcsize(const utf8_int8_t *str) {
   if (0xf0 == (0xf8 & str[0])) {
     // 4 byte utf8 codepoint
     return 4;
@@ -1171,7 +1174,7 @@ utf8_constexpr14 size_t utf8codepointcalcsize(const utf8_int8_t *str) {
   return 1;
 }
 
-utf8_constexpr14 size_t utf8codepointsize(utf8_int32_t chr) {
+utf8_constexpr14_impl size_t utf8codepointsize(utf8_int32_t chr) {
   if (0 == ((utf8_int32_t)0xffffff80 & chr)) {
     return 1;
   } else if (0 == ((utf8_int32_t)0xfffff800 & chr)) {
@@ -1227,9 +1230,9 @@ utf8_int8_t *utf8catcodepoint(utf8_int8_t *str, utf8_int32_t chr, size_t n) {
   return str;
 }
 
-utf8_constexpr14 int utf8islower(utf8_int32_t chr) { return chr != utf8uprcodepoint(chr); }
+utf8_constexpr14_impl int utf8islower(utf8_int32_t chr) { return chr != utf8uprcodepoint(chr); }
 
-utf8_constexpr14 int utf8isupper(utf8_int32_t chr) { return chr != utf8lwrcodepoint(chr); }
+utf8_constexpr14_impl int utf8isupper(utf8_int32_t chr) { return chr != utf8lwrcodepoint(chr); }
 
 void utf8lwr(utf8_int8_t *utf8_restrict str) {
   utf8_int32_t cp = 0;
@@ -1265,7 +1268,7 @@ void utf8upr(utf8_int8_t *utf8_restrict str) {
   }
 }
 
-utf8_constexpr14 utf8_int32_t utf8lwrcodepoint(utf8_int32_t cp) {
+utf8_constexpr14_impl utf8_int32_t utf8lwrcodepoint(utf8_int32_t cp) {
   if (((0x0041 <= cp) && (0x005a >= cp)) ||
       ((0x00c0 <= cp) && (0x00d6 >= cp)) ||
       ((0x00d8 <= cp) && (0x00de >= cp)) ||
@@ -1431,7 +1434,7 @@ utf8_constexpr14 utf8_int32_t utf8lwrcodepoint(utf8_int32_t cp) {
   return cp;
 }
 
-utf8_constexpr14 utf8_int32_t utf8uprcodepoint(utf8_int32_t cp) {
+utf8_constexpr14_impl utf8_int32_t utf8uprcodepoint(utf8_int32_t cp) {
   if (((0x0061 <= cp) && (0x007a >= cp)) ||
       ((0x00e0 <= cp) && (0x00f6 >= cp)) ||
       ((0x00f8 <= cp) && (0x00fe >= cp)) ||
@@ -1597,7 +1600,7 @@ utf8_constexpr14 utf8_int32_t utf8uprcodepoint(utf8_int32_t cp) {
   return cp;
 }
 
-utf8_constexpr14 utf8_int8_t *utf8rcodepoint(const utf8_int8_t *utf8_restrict str,
+utf8_constexpr14_impl utf8_int8_t *utf8rcodepoint(const utf8_int8_t *utf8_restrict str,
                      utf8_int32_t *utf8_restrict out_codepoint) {
   const utf8_int8_t *s = (const utf8_int8_t *)str;
 

--- a/utf8.h
+++ b/utf8.h
@@ -94,76 +94,66 @@ extern "C" {
 #endif
 
 #if defined(__cplusplus) && __cplusplus >= 202002L
-using utf8_t = char8_t; // Introduced in C++20
-#elif defined(__cplusplus)
-using utf8_t = char; // constexpr does not allow cast from void *
+using utf8_int8_t = char8_t; // Introduced in C++20
 #else
-typedef void utf8_t;
+typedef char utf8_int8_t;
 #endif
-
-// Internal type
-#if defined(__cplusplus) && __cplusplus >= 202002L
-using utf8_t_ = char8_t; // Introduced in C++20
-#else
-typedef char utf8_t_;
-#endif
-
 
 // Return less than 0, 0, greater than 0 if src1 < src2, src1 == src2, src1 >
 // src2 respectively, case insensitive.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak int utf8casecmp(const utf8_t *src1,
-                                                                  const utf8_t *src2);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak int utf8casecmp(const utf8_int8_t *src1,
+                                                                  const utf8_int8_t *src2);
 
 // Append the utf8 string src onto the utf8 string dst.
-utf8_nonnull utf8_weak utf8_t *utf8cat(utf8_t *utf8_restrict dst,
-                                       const utf8_t *utf8_restrict src);
+utf8_nonnull utf8_weak utf8_int8_t *utf8cat(utf8_int8_t *utf8_restrict dst,
+                                       const utf8_int8_t *utf8_restrict src);
 
 // Find the first match of the utf8 codepoint chr in the utf8 string src.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak utf8_t *utf8chr(const utf8_t *src,
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak utf8_int8_t *utf8chr(const utf8_int8_t *src,
                                                                   utf8_int32_t chr);
 
 // Return less than 0, 0, greater than 0 if src1 < src2,
 // src1 == src2, src1 > src2 respectively.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak int utf8cmp(const utf8_t *src1,
-                                                              const utf8_t *src2);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak int utf8cmp(const utf8_int8_t *src1,
+                                                              const utf8_int8_t *src2);
 
 // Copy the utf8 string src onto the memory allocated in dst.
-utf8_nonnull utf8_weak utf8_t *utf8cpy(utf8_t *utf8_restrict dst,
-                                       const utf8_t *utf8_restrict src);
+utf8_nonnull utf8_weak utf8_int8_t *utf8cpy(utf8_int8_t *utf8_restrict dst,
+                                       const utf8_int8_t *utf8_restrict src);
 
 // Number of utf8 codepoints in the utf8 string src that consists entirely
 // of utf8 codepoints not from the utf8 string reject.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak size_t utf8cspn(const utf8_t *src,
-                                                                  const utf8_t *reject);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak size_t utf8cspn(const utf8_int8_t *src,
+                                                                  const utf8_int8_t *reject);
 
 // Duplicate the utf8 string src by getting its size, malloc'ing a new buffer
 // copying over the data, and returning that. Or 0 if malloc failed.
-utf8_weak utf8_t *utf8dup(const utf8_t *src);
+utf8_weak utf8_int8_t *utf8dup(const utf8_int8_t *src);
 
 // Number of utf8 codepoints in the utf8 string str,
 // excluding the null terminating byte.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak size_t utf8len(const utf8_t *str);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak size_t utf8len(const utf8_int8_t *str);
 
 // Similar to utf8len, except that only at most n bytes of src are looked.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak size_t utf8nlen(const utf8_t *str, size_t n);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak size_t utf8nlen(const utf8_int8_t *str, size_t n);
 
 // Return less than 0, 0, greater than 0 if src1 < src2, src1 == src2, src1 >
 // src2 respectively, case insensitive. Checking at most n bytes of each utf8
 // string.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak int utf8ncasecmp(const utf8_t *src1,
-                                                                   const utf8_t *src2, size_t n);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak int utf8ncasecmp(const utf8_int8_t *src1,
+                                                                   const utf8_int8_t *src2, size_t n);
 
 // Append the utf8 string src onto the utf8 string dst,
 // writing at most n+1 bytes. Can produce an invalid utf8
 // string if n falls partway through a utf8 codepoint.
-utf8_nonnull utf8_weak utf8_t *utf8ncat(utf8_t *utf8_restrict dst,
-                                        const utf8_t *utf8_restrict src, size_t n);
+utf8_nonnull utf8_weak utf8_int8_t *utf8ncat(utf8_int8_t *utf8_restrict dst,
+                                        const utf8_int8_t *utf8_restrict src, size_t n);
 
 // Return less than 0, 0, greater than 0 if src1 < src2,
 // src1 == src2, src1 > src2 respectively. Checking at most n
 // bytes of each utf8 string.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak int utf8ncmp(const utf8_t *src1,
-                                                               const utf8_t *src2, size_t n);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak int utf8ncmp(const utf8_int8_t *src1,
+                                                               const utf8_int8_t *src2, size_t n);
 
 // Copy the utf8 string src onto the memory allocated in dst.
 // Copies at most n bytes. If n falls partway through a utf8
@@ -171,68 +161,68 @@ utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak int utf8ncmp(const utf8_t *src
 // terminator, the final string will be cut short to preserve
 // utf8 validity.
 
-utf8_nonnull utf8_weak utf8_t *utf8ncpy(utf8_t *utf8_restrict dst,
-                                        const utf8_t *utf8_restrict src, size_t n);
+utf8_nonnull utf8_weak utf8_int8_t *utf8ncpy(utf8_int8_t *utf8_restrict dst,
+                                        const utf8_int8_t *utf8_restrict src, size_t n);
 
 // Similar to utf8dup, except that at most n bytes of src are copied. If src is
 // longer than n, only n bytes are copied and a null byte is added.
 //
 // Returns a new string if successful, 0 otherwise
-utf8_weak utf8_t *utf8ndup(const utf8_t *src, size_t n);
+utf8_weak utf8_int8_t *utf8ndup(const utf8_int8_t *src, size_t n);
 
 // Locates the first occurrence in the utf8 string str of any byte in the
 // utf8 string accept, or 0 if no match was found.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak utf8_t *utf8pbrk(const utf8_t *str,
-                                                                   const utf8_t *accept);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak utf8_int8_t *utf8pbrk(const utf8_int8_t *str,
+                                                                   const utf8_int8_t *accept);
 
 // Find the last match of the utf8 codepoint chr in the utf8 string src.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak utf8_t *utf8rchr(const utf8_t *src, int chr);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak utf8_int8_t *utf8rchr(const utf8_int8_t *src, int chr);
 
 // Number of bytes in the utf8 string str,
 // including the null terminating byte.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak size_t utf8size(const utf8_t *str);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak size_t utf8size(const utf8_int8_t *str);
 
 // Similar to utf8size, except that the null terminating byte is excluded.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak size_t utf8size_lazy(const utf8_t *str);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak size_t utf8size_lazy(const utf8_int8_t *str);
 
 // Similar to utf8size, except that only at most n bytes of src are looked and
 // the null terminating byte is excluded.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak size_t utf8nsize_lazy(const utf8_t *str, size_t n);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak size_t utf8nsize_lazy(const utf8_int8_t *str, size_t n);
 
 // Number of utf8 codepoints in the utf8 string src that consists entirely
 // of utf8 codepoints from the utf8 string accept.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak size_t utf8spn(const utf8_t *src,
-                                                                 const utf8_t *accept);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak size_t utf8spn(const utf8_int8_t *src,
+                                                                 const utf8_int8_t *accept);
 
 // The position of the utf8 string needle in the utf8 string haystack.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak utf8_t *utf8str(const utf8_t *haystack,
-                                                                  const utf8_t *needle);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak utf8_int8_t *utf8str(const utf8_int8_t *haystack,
+                                                                  const utf8_int8_t *needle);
 
 // The position of the utf8 string needle in the utf8 string haystack, case
 // insensitive.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak utf8_t *utf8casestr(const utf8_t *haystack,
-                                                                      const utf8_t *needle);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak utf8_int8_t *utf8casestr(const utf8_int8_t *haystack,
+                                                                      const utf8_int8_t *needle);
 
 // Return 0 on success, or the position of the invalid
 // utf8 codepoint on failure.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak utf8_t *utf8valid(const utf8_t *str);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak utf8_int8_t *utf8valid(const utf8_int8_t *str);
 
 // Similar to utf8valid, except that only at most n bytes of src are looked.
-utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak utf8_t *utf8nvalid(const utf8_t *str, size_t n);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak utf8_int8_t *utf8nvalid(const utf8_int8_t *str, size_t n);
 
 // Given a null-terminated string, makes the string valid by replacing invalid
 // codepoints with a 1-byte replacement. Returns 0 on success.
-utf8_nonnull utf8_weak int utf8makevalid(utf8_t *str,
+utf8_nonnull utf8_weak int utf8makevalid(utf8_int8_t *str,
                                          const utf8_int32_t replacement);
 
 // Sets out_codepoint to the current utf8 codepoint in str, and returns the
 // address of the next utf8 codepoint after the current one in str.
-utf8_constexpr14 utf8_nonnull utf8_weak utf8_t *
-utf8codepoint(const utf8_t *utf8_restrict str,
+utf8_constexpr14 utf8_nonnull utf8_weak utf8_int8_t *
+utf8codepoint(const utf8_int8_t *utf8_restrict str,
               utf8_int32_t *utf8_restrict out_codepoint);
 
 // Calculates the size of the next utf8 codepoint in str.
-utf8_constexpr14 utf8_nonnull utf8_weak size_t utf8codepointcalcsize(const utf8_t *str);
+utf8_constexpr14 utf8_nonnull utf8_weak size_t utf8codepointcalcsize(const utf8_int8_t *str);
 
 // Returns the size of the given codepoint in bytes.
 utf8_constexpr14 utf8_weak size_t utf8codepointsize(utf8_int32_t chr);
@@ -241,7 +231,7 @@ utf8_constexpr14 utf8_weak size_t utf8codepointsize(utf8_int32_t chr);
 // place after the written codepoint. Pass how many bytes left in the buffer to
 // n. If there is not enough space for the codepoint, this function returns
 // null.
-utf8_nonnull utf8_weak utf8_t *utf8catcodepoint(utf8_t *str, utf8_int32_t chr,
+utf8_nonnull utf8_weak utf8_int8_t *utf8catcodepoint(utf8_int8_t *str, utf8_int32_t chr,
                                                 size_t n);
 
 // Returns 1 if the given character is lowercase, or 0 if it is not.
@@ -251,10 +241,10 @@ utf8_constexpr14 utf8_weak int utf8islower(utf8_int32_t chr);
 utf8_constexpr14 utf8_weak int utf8isupper(utf8_int32_t chr);
 
 // Transform the given string into all lowercase codepoints.
-utf8_nonnull utf8_weak void utf8lwr(utf8_t *utf8_restrict str);
+utf8_nonnull utf8_weak void utf8lwr(utf8_int8_t *utf8_restrict str);
 
 // Transform the given string into all uppercase codepoints.
-utf8_nonnull utf8_weak void utf8upr(utf8_t *utf8_restrict str);
+utf8_nonnull utf8_weak void utf8upr(utf8_int8_t *utf8_restrict str);
 
 // Make a codepoint lower case if possible.
 utf8_constexpr14 utf8_weak utf8_int32_t utf8lwrcodepoint(utf8_int32_t cp);
@@ -264,30 +254,30 @@ utf8_constexpr14 utf8_weak utf8_int32_t utf8uprcodepoint(utf8_int32_t cp);
 
 // Sets out_codepoint to the current utf8 codepoint in str, and returns the
 // address of the previous utf8 codepoint before the current one in str.
-utf8_constexpr14 utf8_nonnull utf8_weak utf8_t *
-utf8rcodepoint(const utf8_t *utf8_restrict str,
+utf8_constexpr14 utf8_nonnull utf8_weak utf8_int8_t *
+utf8rcodepoint(const utf8_int8_t *utf8_restrict str,
                utf8_int32_t *utf8_restrict out_codepoint);
 
 // Duplicate the utf8 string src by getting its size, calling alloc_func_ptr to
 // copy over data to a new buffer, and returning that. Or 0 if alloc_func_ptr
 // returned null.
-utf8_weak utf8_t *utf8dup_ex(const utf8_t *src,
-                             utf8_t *(*alloc_func_ptr)(utf8_t *, size_t),
-                             utf8_t *user_data);
+utf8_weak utf8_int8_t *utf8dup_ex(const utf8_int8_t *src,
+                             utf8_int8_t *(*alloc_func_ptr)(utf8_int8_t *, size_t),
+                             utf8_int8_t *user_data);
 
 // Similar to utf8dup, except that at most n bytes of src are copied. If src is
 // longer than n, only n bytes are copied and a null byte is added.
 //
 // Returns a new string if successful, 0 otherwise.
-utf8_weak utf8_t *utf8ndup_ex(const utf8_t *src, size_t n,
-                              utf8_t *(*alloc_func_ptr)(utf8_t *, size_t),
-                              utf8_t *user_data);
+utf8_weak utf8_int8_t *utf8ndup_ex(const utf8_int8_t *src, size_t n,
+                              utf8_int8_t *(*alloc_func_ptr)(utf8_int8_t *, size_t),
+                              utf8_int8_t *user_data);
 
 #undef utf8_weak
 #undef utf8_pure
 #undef utf8_nonnull
 
-utf8_constexpr14 int utf8casecmp(const utf8_t *src1, const utf8_t *src2) {
+utf8_constexpr14 int utf8casecmp(const utf8_int8_t *src1, const utf8_int8_t *src2) {
   utf8_int32_t src1_lwr_cp = 0, src2_lwr_cp = 0, src1_upr_cp = 0,
         src2_upr_cp = 0, src1_orig_cp = 0, src2_orig_cp = 0;
 
@@ -315,9 +305,9 @@ utf8_constexpr14 int utf8casecmp(const utf8_t *src1, const utf8_t *src2) {
   }
 }
 
-utf8_t *utf8cat(utf8_t *utf8_restrict dst, const utf8_t *utf8_restrict src) {
-  utf8_t_ *d = (utf8_t_ *)dst;
-  const utf8_t_ *s = (const utf8_t_ *)src;
+utf8_int8_t *utf8cat(utf8_int8_t *utf8_restrict dst, const utf8_int8_t *utf8_restrict src) {
+  utf8_int8_t *d = (utf8_int8_t *)dst;
+  const utf8_int8_t *s = (const utf8_int8_t *)src;
 
   // find the null terminating byte in dst
   while ('\0' != *d) {
@@ -335,39 +325,39 @@ utf8_t *utf8cat(utf8_t *utf8_restrict dst, const utf8_t *utf8_restrict src) {
   return dst;
 }
 
-utf8_constexpr14 utf8_t *utf8chr(const utf8_t *src, utf8_int32_t chr) {
-  utf8_t_ c[5] = {'\0', '\0', '\0', '\0', '\0'};
+utf8_constexpr14 utf8_int8_t *utf8chr(const utf8_int8_t *src, utf8_int32_t chr) {
+  utf8_int8_t c[5] = {'\0', '\0', '\0', '\0', '\0'};
 
   if (0 == chr) {
     // being asked to return position of null terminating byte, so
     // just run s to the end, and return!
-    const utf8_t_ *s = (const utf8_t_ *)src;
+    const utf8_int8_t *s = (const utf8_int8_t *)src;
     while ('\0' != *s) {
       s++;
     }
-    return (utf8_t *)s;
+    return (utf8_int8_t *)s;
   } else if (0 == ((utf8_int32_t)0xffffff80 & chr)) {
     // 1-byte/7-bit ascii
     // (0b0xxxxxxx)
-    c[0] = (utf8_t_) chr;
+    c[0] = (utf8_int8_t) chr;
   } else if (0 == ((utf8_int32_t)0xfffff800 & chr)) {
     // 2-byte/11-bit utf8 code point
     // (0b110xxxxx 0b10xxxxxx)
-    c[0] = (utf8_t_)  (0xc0 | (utf8_t_) (chr >> 6));
-    c[1] = (utf8_t_)  (0x80 | (utf8_t_) (chr & 0x3f));
+    c[0] = (utf8_int8_t)  (0xc0 | (utf8_int8_t) (chr >> 6));
+    c[1] = (utf8_int8_t)  (0x80 | (utf8_int8_t) (chr & 0x3f));
   } else if (0 == ((utf8_int32_t)0xffff0000 & chr)) {
     // 3-byte/16-bit utf8 code point
     // (0b1110xxxx 0b10xxxxxx 0b10xxxxxx)
-    c[0] = (utf8_t_)  (0xe0 | (utf8_t_) (chr >> 12));
-    c[1] = (utf8_t_)  (0x80 | (utf8_t_) ((chr >> 6) & 0x3f));
-    c[2] = (utf8_t_)  (0x80 | (utf8_t_) (chr & 0x3f));
+    c[0] = (utf8_int8_t)  (0xe0 | (utf8_int8_t) (chr >> 12));
+    c[1] = (utf8_int8_t)  (0x80 | (utf8_int8_t) ((chr >> 6) & 0x3f));
+    c[2] = (utf8_int8_t)  (0x80 | (utf8_int8_t) (chr & 0x3f));
   } else { // if (0 == ((int)0xffe00000 & chr)) {
     // 4-byte/21-bit utf8 code point
     // (0b11110xxx 0b10xxxxxx 0b10xxxxxx 0b10xxxxxx)
-    c[0] = (utf8_t_)  (0xf0 | (utf8_t_) (chr >> 18));
-    c[1] = (utf8_t_)  (0x80 | (utf8_t_) ((chr >> 12) & 0x3f));
-    c[2] = (utf8_t_)  (0x80 | (utf8_t_) ((chr >> 6) & 0x3f));
-    c[3] = (utf8_t_)  (0x80 | (utf8_t_) (chr & 0x3f));
+    c[0] = (utf8_int8_t)  (0xf0 | (utf8_int8_t) (chr >> 18));
+    c[1] = (utf8_int8_t)  (0x80 | (utf8_int8_t) ((chr >> 12) & 0x3f));
+    c[2] = (utf8_int8_t)  (0x80 | (utf8_int8_t) ((chr >> 6) & 0x3f));
+    c[3] = (utf8_int8_t)  (0x80 | (utf8_int8_t) (chr & 0x3f));
   }
 
   // we've made c into a 2 utf8 codepoint string, one for the chr we are
@@ -376,9 +366,9 @@ utf8_constexpr14 utf8_t *utf8chr(const utf8_t *src, utf8_int32_t chr) {
   return utf8str(src, c);
 }
 
-utf8_constexpr14 int utf8cmp(const utf8_t *src1, const utf8_t *src2) {
-  const utf8_t_ *s1 = (const utf8_t_ *)src1;
-  const utf8_t_ *s2 = (const utf8_t_ *)src2;
+utf8_constexpr14 int utf8cmp(const utf8_int8_t *src1, const utf8_int8_t *src2) {
+  const utf8_int8_t *s1 = (const utf8_int8_t *)src1;
+  const utf8_int8_t *s2 = (const utf8_int8_t *)src2;
 
   while (('\0' != *s1) || ('\0' != *s2)) {
     if (*s1 < *s2) {
@@ -395,11 +385,11 @@ utf8_constexpr14 int utf8cmp(const utf8_t *src1, const utf8_t *src2) {
   return 0;
 }
 
-utf8_constexpr14 int utf8coll(const utf8_t *src1, const utf8_t *src2);
+utf8_constexpr14 int utf8coll(const utf8_int8_t *src1, const utf8_int8_t *src2);
 
-utf8_t *utf8cpy(utf8_t *utf8_restrict dst, const utf8_t *utf8_restrict src) {
-  utf8_t_ *d = (utf8_t_ *)dst;
-  const utf8_t_ *s = (const utf8_t_ *)src;
+utf8_int8_t *utf8cpy(utf8_int8_t *utf8_restrict dst, const utf8_int8_t *utf8_restrict src) {
+  utf8_int8_t *d = (utf8_int8_t *)dst;
+  const utf8_int8_t *s = (const utf8_int8_t *)src;
 
   // overwriting anything previously in dst, write byte-by-byte
   // from src
@@ -413,12 +403,12 @@ utf8_t *utf8cpy(utf8_t *utf8_restrict dst, const utf8_t *utf8_restrict src) {
   return dst;
 }
 
-utf8_constexpr14 size_t utf8cspn(const utf8_t *src, const utf8_t *reject) {
-  const utf8_t_ *s = (const utf8_t_ *)src;
+utf8_constexpr14 size_t utf8cspn(const utf8_int8_t *src, const utf8_int8_t *reject) {
+  const utf8_int8_t *s = (const utf8_int8_t *)src;
   size_t chars = 0;
 
   while ('\0' != *s) {
-    const utf8_t_ *r = (const utf8_t_ *)reject;
+    const utf8_int8_t *r = (const utf8_int8_t *)reject;
     size_t offset = 0;
 
     while ('\0' != *r) {
@@ -464,20 +454,20 @@ utf8_constexpr14 size_t utf8cspn(const utf8_t *src, const utf8_t *reject) {
   return chars;
 }
 
-utf8_t *utf8dup(const utf8_t *src) { return utf8dup_ex(src, utf8_null, utf8_null); }
+utf8_int8_t *utf8dup(const utf8_int8_t *src) { return utf8dup_ex(src, utf8_null, utf8_null); }
 
-utf8_t *utf8dup_ex(const utf8_t *src, utf8_t *(*alloc_func_ptr)(utf8_t *, size_t),
-                                  utf8_t *user_data) {
-  const utf8_t_ *s = (const utf8_t_ *)src;
-  utf8_t_ *n = utf8_null;
+utf8_int8_t *utf8dup_ex(const utf8_int8_t *src, utf8_int8_t *(*alloc_func_ptr)(utf8_int8_t *, size_t),
+                                  utf8_int8_t *user_data) {
+  const utf8_int8_t *s = (const utf8_int8_t *)src;
+  utf8_int8_t *n = utf8_null;
 
   // figure out how many bytes (including the terminator) we need to copy first
   size_t bytes = utf8size(src);
 
   if (alloc_func_ptr) {
-    n = (utf8_t_ *)alloc_func_ptr(user_data, bytes);
+    n = (utf8_int8_t *)alloc_func_ptr(user_data, bytes);
   } else {
-    n = (utf8_t_ *)malloc(bytes);
+    n = (utf8_int8_t *)malloc(bytes);
   }
 
   if (utf8_null == n) {
@@ -498,15 +488,15 @@ utf8_t *utf8dup_ex(const utf8_t *src, utf8_t *(*alloc_func_ptr)(utf8_t *, size_t
   }
 }
 
-utf8_constexpr14 utf8_t *utf8fry(const utf8_t *str);
+utf8_constexpr14 utf8_int8_t *utf8fry(const utf8_int8_t *str);
 
-utf8_constexpr14 size_t utf8len(const utf8_t *str) {
+utf8_constexpr14 size_t utf8len(const utf8_int8_t *str) {
   return utf8nlen(str, SIZE_MAX);
 }
 
-utf8_constexpr14 size_t utf8nlen(const utf8_t *str, size_t n) {
-  const utf8_t_ *s = (const utf8_t_ *)str;
-  const utf8_t_ *t = s;
+utf8_constexpr14 size_t utf8nlen(const utf8_int8_t *str, size_t n) {
+  const utf8_int8_t *s = (const utf8_int8_t *)str;
+  const utf8_int8_t *t = s;
   size_t length = 0;
 
   while ((size_t) (s-t) < n && '\0' != *s) {
@@ -535,13 +525,13 @@ utf8_constexpr14 size_t utf8nlen(const utf8_t *str, size_t n) {
   return length;
 }
 
-utf8_constexpr14 int utf8ncasecmp(const utf8_t *src1, const utf8_t *src2, size_t n) {
+utf8_constexpr14 int utf8ncasecmp(const utf8_int8_t *src1, const utf8_int8_t *src2, size_t n) {
   utf8_int32_t src1_lwr_cp = 0, src2_lwr_cp = 0, src1_upr_cp = 0, src2_upr_cp = 0,
         src1_orig_cp = 0, src2_orig_cp = 0;
 
   do {
-    const utf8_t_ *const s1 = (const utf8_t_ *)src1;
-    const utf8_t_ *const s2 = (const utf8_t_ *)src2;
+    const utf8_int8_t *const s1 = (const utf8_int8_t *)src1;
+    const utf8_int8_t *const s2 = (const utf8_int8_t *)src2;
 
     // first check that we have enough bytes left in n to contain an entire
     // codepoint
@@ -607,10 +597,10 @@ utf8_constexpr14 int utf8ncasecmp(const utf8_t *src1, const utf8_t *src2, size_t
   return 0;
 }
 
-utf8_t *utf8ncat(utf8_t *utf8_restrict dst, const utf8_t *utf8_restrict src,
+utf8_int8_t *utf8ncat(utf8_int8_t *utf8_restrict dst, const utf8_int8_t *utf8_restrict src,
                size_t n) {
-  utf8_t_ *d = (utf8_t_ *)dst;
-  const utf8_t_ *s = (const utf8_t_ *)src;
+  utf8_int8_t *d = (utf8_int8_t *)dst;
+  const utf8_int8_t *s = (const utf8_int8_t *)src;
 
   // find the null terminating byte in dst
   while ('\0' != *d) {
@@ -629,9 +619,9 @@ utf8_t *utf8ncat(utf8_t *utf8_restrict dst, const utf8_t *utf8_restrict src,
   return dst;
 }
 
-utf8_constexpr14 int utf8ncmp(const utf8_t *src1, const utf8_t *src2, size_t n) {
-  const utf8_t_ *s1 = (const utf8_t_ *)src1;
-  const utf8_t_ *s2 = (const utf8_t_ *)src2;
+utf8_constexpr14 int utf8ncmp(const utf8_int8_t *src1, const utf8_int8_t *src2, size_t n) {
+  const utf8_int8_t *s1 = (const utf8_int8_t *)src1;
+  const utf8_int8_t *s2 = (const utf8_int8_t *)src2;
 
   while ((0 != n--) && (('\0' != *s1) || ('\0' != *s2))) {
     if (*s1 < *s2) {
@@ -648,10 +638,10 @@ utf8_constexpr14 int utf8ncmp(const utf8_t *src1, const utf8_t *src2, size_t n) 
   return 0;
 }
 
-utf8_t *utf8ncpy(utf8_t *utf8_restrict dst, const utf8_t *utf8_restrict src,
+utf8_int8_t *utf8ncpy(utf8_int8_t *utf8_restrict dst, const utf8_int8_t *utf8_restrict src,
                size_t n) {
-  utf8_t_ *d = (utf8_t_ *)dst;
-  const utf8_t_ *s = (const utf8_t_ *)src;
+  utf8_int8_t *d = (utf8_int8_t *)dst;
+  const utf8_int8_t *s = (const utf8_int8_t *)src;
   size_t index = 0, check_index = 0;
 
   if (n == 0) {
@@ -683,14 +673,14 @@ utf8_t *utf8ncpy(utf8_t *utf8_restrict dst, const utf8_t *utf8_restrict src,
   return dst;
 }
 
-utf8_t *utf8ndup(const utf8_t *src, size_t n) {
+utf8_int8_t *utf8ndup(const utf8_int8_t *src, size_t n) {
   return utf8ndup_ex(src, n, utf8_null, utf8_null);
 }
 
-utf8_t *utf8ndup_ex(const utf8_t *src, size_t n,
-                  utf8_t *(*alloc_func_ptr)(utf8_t *, size_t), utf8_t *user_data) {
-  const utf8_t_ *s = (const utf8_t_ *)src;
-  utf8_t_ *c = utf8_null;
+utf8_int8_t *utf8ndup_ex(const utf8_int8_t *src, size_t n,
+                  utf8_int8_t *(*alloc_func_ptr)(utf8_int8_t *, size_t), utf8_int8_t *user_data) {
+  const utf8_int8_t *s = (const utf8_int8_t *)src;
+  utf8_int8_t *c = utf8_null;
   size_t bytes = 0;
 
   // Find the end of the string or stop when n is reached
@@ -703,9 +693,9 @@ utf8_t *utf8ndup_ex(const utf8_t *src, size_t n,
   n = bytes;
 
   if (alloc_func_ptr) {
-    c = (utf8_t_ *)alloc_func_ptr(user_data, bytes + 1);
+    c = (utf8_int8_t *)alloc_func_ptr(user_data, bytes + 1);
   } else {
-    c = (utf8_t_ *)malloc(bytes + 1);
+    c = (utf8_int8_t *)malloc(bytes + 1);
   }
 
   if (utf8_null == c) {
@@ -726,10 +716,10 @@ utf8_t *utf8ndup_ex(const utf8_t *src, size_t n,
   return c;
 }
 
-utf8_constexpr14 utf8_t *utf8rchr(const utf8_t *src, int chr) {
-  const utf8_t_ *s = (const utf8_t_ *)src;
-  const utf8_t_ *match = utf8_null;
-  utf8_t_ c[5] = {'\0', '\0', '\0', '\0', '\0'};
+utf8_constexpr14 utf8_int8_t *utf8rchr(const utf8_int8_t *src, int chr) {
+  const utf8_int8_t *s = (const utf8_int8_t *)src;
+  const utf8_int8_t *match = utf8_null;
+  utf8_int8_t c[5] = {'\0', '\0', '\0', '\0', '\0'};
 
   if (0 == chr) {
     // being asked to return position of null terminating byte, so
@@ -737,29 +727,29 @@ utf8_constexpr14 utf8_t *utf8rchr(const utf8_t *src, int chr) {
     while ('\0' != *s) {
       s++;
     }
-    return (utf8_t *)s;
+    return (utf8_int8_t *)s;
   } else if (0 == ((int)0xffffff80 & chr)) {
     // 1-byte/7-bit ascii
     // (0b0xxxxxxx)
-    c[0] = (utf8_t_) chr;
+    c[0] = (utf8_int8_t) chr;
   } else if (0 == ((int)0xfffff800 & chr)) {
     // 2-byte/11-bit utf8 code point
     // (0b110xxxxx 0b10xxxxxx)
-    c[0] = (utf8_t_)  (0xc0 | (utf8_t_) (chr >> 6));
-    c[1] = (utf8_t_)  (0x80 | (utf8_t_) (chr & 0x3f));
+    c[0] = (utf8_int8_t)  (0xc0 | (utf8_int8_t) (chr >> 6));
+    c[1] = (utf8_int8_t)  (0x80 | (utf8_int8_t) (chr & 0x3f));
   } else if (0 == ((int)0xffff0000 & chr)) {
     // 3-byte/16-bit utf8 code point
     // (0b1110xxxx 0b10xxxxxx 0b10xxxxxx)
-    c[0] = (utf8_t_)  (0xe0 | (utf8_t_) (chr >> 12));
-    c[1] = (utf8_t_)  (0x80 | (utf8_t_) ((chr >> 6) & 0x3f));
-    c[2] = (utf8_t_)  (0x80 | (utf8_t_) (chr & 0x3f));
+    c[0] = (utf8_int8_t)  (0xe0 | (utf8_int8_t) (chr >> 12));
+    c[1] = (utf8_int8_t)  (0x80 | (utf8_int8_t) ((chr >> 6) & 0x3f));
+    c[2] = (utf8_int8_t)  (0x80 | (utf8_int8_t) (chr & 0x3f));
   } else { // if (0 == ((int)0xffe00000 & chr)) {
     // 4-byte/21-bit utf8 code point
     // (0b11110xxx 0b10xxxxxx 0b10xxxxxx 0b10xxxxxx)
-    c[0] = (utf8_t_)  (0xf0 | (utf8_t_) (chr >> 18));
-    c[1] = (utf8_t_)  (0x80 | (utf8_t_) ((chr >> 12) & 0x3f));
-    c[2] = (utf8_t_)  (0x80 | (utf8_t_) ((chr >> 6) & 0x3f));
-    c[3] = (utf8_t_)  (0x80 | (utf8_t_) (chr & 0x3f));
+    c[0] = (utf8_int8_t)  (0xf0 | (utf8_int8_t) (chr >> 18));
+    c[1] = (utf8_int8_t)  (0x80 | (utf8_int8_t) ((chr >> 12) & 0x3f));
+    c[2] = (utf8_int8_t)  (0x80 | (utf8_int8_t) ((chr >> 6) & 0x3f));
+    c[3] = (utf8_int8_t)  (0x80 | (utf8_int8_t) (chr & 0x3f));
   }
 
   // we've created a 2 utf8 codepoint string in c that is
@@ -791,14 +781,14 @@ utf8_constexpr14 utf8_t *utf8rchr(const utf8_t *src, int chr) {
   }
 
   // return the last match we found (or 0 if no match was found)
-  return (utf8_t *)match;
+  return (utf8_int8_t *)match;
 }
 
-utf8_constexpr14 utf8_t *utf8pbrk(const utf8_t *str, const utf8_t *accept) {
-  const utf8_t_ *s = (const utf8_t_ *)str;
+utf8_constexpr14 utf8_int8_t *utf8pbrk(const utf8_int8_t *str, const utf8_int8_t *accept) {
+  const utf8_int8_t *s = (const utf8_int8_t *)str;
 
   while ('\0' != *s) {
-    const utf8_t_ *a = (const utf8_t_ *)accept;
+    const utf8_int8_t *a = (const utf8_int8_t *)accept;
     size_t offset = 0;
 
     while ('\0' != *a) {
@@ -806,7 +796,7 @@ utf8_constexpr14 utf8_t *utf8pbrk(const utf8_t *str, const utf8_t *accept) {
       // (it is not 0b10xxxxxx) and we have successfully matched
       // a previous character (0 < offset) - we found a match
       if ((0x80 != (0xc0 & *a)) && (0 < offset)) {
-        return (utf8_t *)s;
+        return (utf8_int8_t *)s;
       } else {
         if (*a == s[offset]) {
           // part of a utf8 codepoint matched, so move our checking
@@ -829,7 +819,7 @@ utf8_constexpr14 utf8_t *utf8pbrk(const utf8_t *str, const utf8_t *accept) {
 
     // we found a match on the last utf8 codepoint
     if (0 < offset) {
-      return (utf8_t *)s;
+      return (utf8_int8_t *)s;
     }
 
     // the current utf8 codepoint in src did not match accept, but src
@@ -843,16 +833,16 @@ utf8_constexpr14 utf8_t *utf8pbrk(const utf8_t *str, const utf8_t *accept) {
   return utf8_null;
 }
 
-utf8_constexpr14 size_t utf8size(const utf8_t *str) {
+utf8_constexpr14 size_t utf8size(const utf8_int8_t *str) {
   return utf8size_lazy(str) + 1;
 }
 
-utf8_constexpr14 size_t utf8size_lazy(const utf8_t *str) {
+utf8_constexpr14 size_t utf8size_lazy(const utf8_int8_t *str) {
   return utf8nsize_lazy(str, SIZE_MAX);
 }
 
-utf8_constexpr14 size_t utf8nsize_lazy(const utf8_t *str, size_t n) {
-  const utf8_t_ *s = (const utf8_t_ *)str;
+utf8_constexpr14 size_t utf8nsize_lazy(const utf8_int8_t *str, size_t n) {
+  const utf8_int8_t *s = (const utf8_int8_t *)str;
   size_t size = 0;
   while (size < n && '\0' != s[size]) {
     size++;
@@ -860,12 +850,12 @@ utf8_constexpr14 size_t utf8nsize_lazy(const utf8_t *str, size_t n) {
   return size;
 }
 
-utf8_constexpr14 size_t utf8spn(const utf8_t *src, const utf8_t *accept) {
-  const utf8_t_ *s = (const utf8_t_ *)src;
+utf8_constexpr14 size_t utf8spn(const utf8_int8_t *src, const utf8_int8_t *accept) {
+  const utf8_int8_t *s = (const utf8_int8_t *)src;
   size_t chars = 0;
 
   while ('\0' != *s) {
-    const utf8_t_ *a = (const utf8_t_ *)accept;
+    const utf8_int8_t *a = (const utf8_int8_t *)accept;
     size_t offset = 0;
 
     while ('\0' != *a) {
@@ -914,19 +904,19 @@ utf8_constexpr14 size_t utf8spn(const utf8_t *src, const utf8_t *accept) {
   return chars;
 }
 
-utf8_constexpr14 utf8_t *utf8str(const utf8_t *haystack, const utf8_t *needle) {
-  const utf8_t_ *h = (const utf8_t_ *)haystack;
+utf8_constexpr14 utf8_int8_t *utf8str(const utf8_int8_t *haystack, const utf8_int8_t *needle) {
+  const utf8_int8_t *h = (const utf8_int8_t *)haystack;
   utf8_int32_t throwaway_codepoint = 0;
 
   // if needle has no utf8 codepoints before the null terminating
   // byte then return haystack
-  if ('\0' == *((const utf8_t_ *)needle)) {
-    return (utf8_t *)haystack;
+  if ('\0' == *((const utf8_int8_t *)needle)) {
+    return (utf8_int8_t *)haystack;
   }
 
   while ('\0' != *h) {
-    const utf8_t_ *maybeMatch = h;
-    const utf8_t_ *n = (const utf8_t_ *)needle;
+    const utf8_int8_t *maybeMatch = h;
+    const utf8_int8_t *n = (const utf8_int8_t *)needle;
 
     while (*h == *n && (*h != '\0' && *n != '\0')) {
       n++;
@@ -936,12 +926,12 @@ utf8_constexpr14 utf8_t *utf8str(const utf8_t *haystack, const utf8_t *needle) {
     if ('\0' == *n) {
       // we found the whole utf8 string for needle in haystack at
       // maybeMatch, so return it
-      return (utf8_t *)maybeMatch;
+      return (utf8_int8_t *)maybeMatch;
     } else {
       // h could be in the middle of an unmatching utf8 codepoint,
       // so we need to march it on to the next character beginning
       // starting from the current character
-      h = (const utf8_t_ *)utf8codepoint(maybeMatch, &throwaway_codepoint);
+      h = (const utf8_int8_t *)utf8codepoint(maybeMatch, &throwaway_codepoint);
     }
   }
 
@@ -949,22 +939,22 @@ utf8_constexpr14 utf8_t *utf8str(const utf8_t *haystack, const utf8_t *needle) {
   return utf8_null;
 }
 
-utf8_constexpr14 utf8_t *utf8casestr(const utf8_t *haystack, const utf8_t *needle) {
-  const utf8_t *h = haystack;
+utf8_constexpr14 utf8_int8_t *utf8casestr(const utf8_int8_t *haystack, const utf8_int8_t *needle) {
+  const utf8_int8_t *h = haystack;
 
   // if needle has no utf8 codepoints before the null terminating
   // byte then return haystack
-  if ('\0' == *((const utf8_t_ *)needle)) {
-    return (utf8_t *)haystack;
+  if ('\0' == *((const utf8_int8_t *)needle)) {
+    return (utf8_int8_t *)haystack;
   }
 
   for (;;) {
-    const utf8_t *maybeMatch = h;
-    const utf8_t *n = needle;
+    const utf8_int8_t *maybeMatch = h;
+    const utf8_int8_t *n = needle;
     utf8_int32_t h_cp = 0, n_cp = 0;
 
     // Get the next code point and track it
-    const utf8_t *nextH = h = utf8codepoint(h, &h_cp);
+    const utf8_int8_t *nextH = h = utf8codepoint(h, &h_cp);
     n = utf8codepoint(n, &n_cp);
 
     while ((0 != h_cp) && (0 != n_cp)) {
@@ -983,7 +973,7 @@ utf8_constexpr14 utf8_t *utf8casestr(const utf8_t *haystack, const utf8_t *needl
     if (0 == n_cp) {
       // we found the whole utf8 string for needle in haystack at
       // maybeMatch, so return it
-      return (utf8_t *)maybeMatch;
+      return (utf8_int8_t *)maybeMatch;
     }
 
     if (0 == h_cp) {
@@ -996,13 +986,13 @@ utf8_constexpr14 utf8_t *utf8casestr(const utf8_t *haystack, const utf8_t *needl
   }
 }
 
-utf8_constexpr14 utf8_t *utf8valid(const utf8_t *str) {
+utf8_constexpr14 utf8_int8_t *utf8valid(const utf8_int8_t *str) {
   return utf8nvalid(str, SIZE_MAX);
 }
 
-utf8_constexpr14 utf8_t *utf8nvalid(const utf8_t *str, size_t n) {
-  const utf8_t_ *s = (const utf8_t_ *)str;
-  const utf8_t_ *t = s;
+utf8_constexpr14 utf8_int8_t *utf8nvalid(const utf8_int8_t *str, size_t n) {
+  const utf8_int8_t *s = (const utf8_int8_t *)str;
+  const utf8_int8_t *t = s;
   size_t consumed = 0, remained = 0;
 
   while ((void) (consumed = (size_t) (s-t)), consumed < n && '\0' != *s) {
@@ -1011,26 +1001,26 @@ utf8_constexpr14 utf8_t *utf8nvalid(const utf8_t *str, size_t n) {
     if (0xf0 == (0xf8 & *s)) {
       // ensure that there's 4 bytes or more remained
       if (remained < 4) {
-        return (utf8_t *)s;
+        return (utf8_int8_t *)s;
       }
 
       // ensure each of the 3 following bytes in this 4-byte
       // utf8 codepoint began with 0b10xxxxxx
       if ((0x80 != (0xc0 & s[1])) || (0x80 != (0xc0 & s[2])) ||
           (0x80 != (0xc0 & s[3]))) {
-        return (utf8_t *)s;
+        return (utf8_int8_t *)s;
       }
 
       // ensure that our utf8 codepoint ended after 4 bytes
       if (0x80 == (0xc0 & s[4])) {
-        return (utf8_t *)s;
+        return (utf8_int8_t *)s;
       }
 
       // ensure that the top 5 bits of this 4-byte utf8
       // codepoint were not 0, as then we could have used
       // one of the smaller encodings
       if ((0 == (0x07 & s[0])) && (0 == (0x30 & s[1]))) {
-        return (utf8_t *)s;
+        return (utf8_int8_t *)s;
       }
 
       // 4-byte utf8 code point (began with 0b11110xxx)
@@ -1038,25 +1028,25 @@ utf8_constexpr14 utf8_t *utf8nvalid(const utf8_t *str, size_t n) {
     } else if (0xe0 == (0xf0 & *s)) {
       // ensure that there's 3 bytes or more remained
       if (remained < 3) {
-        return (utf8_t *)s;
+        return (utf8_int8_t *)s;
       }
 
       // ensure each of the 2 following bytes in this 3-byte
       // utf8 codepoint began with 0b10xxxxxx
       if ((0x80 != (0xc0 & s[1])) || (0x80 != (0xc0 & s[2]))) {
-        return (utf8_t *)s;
+        return (utf8_int8_t *)s;
       }
 
       // ensure that our utf8 codepoint ended after 3 bytes
       if (0x80 == (0xc0 & s[3])) {
-        return (utf8_t *)s;
+        return (utf8_int8_t *)s;
       }
 
       // ensure that the top 5 bits of this 3-byte utf8
       // codepoint were not 0, as then we could have used
       // one of the smaller encodings
       if ((0 == (0x0f & s[0])) && (0 == (0x20 & s[1]))) {
-        return (utf8_t *)s;
+        return (utf8_int8_t *)s;
       }
 
       // 3-byte utf8 code point (began with 0b1110xxxx)
@@ -1064,25 +1054,25 @@ utf8_constexpr14 utf8_t *utf8nvalid(const utf8_t *str, size_t n) {
     } else if (0xc0 == (0xe0 & *s)) {
       // ensure that there's 2 bytes or more remained
       if (remained < 2) {
-        return (utf8_t *)s;
+        return (utf8_int8_t *)s;
       }
 
       // ensure the 1 following byte in this 2-byte
       // utf8 codepoint began with 0b10xxxxxx
       if (0x80 != (0xc0 & s[1])) {
-        return (utf8_t *)s;
+        return (utf8_int8_t *)s;
       }
 
       // ensure that our utf8 codepoint ended after 2 bytes
       if (0x80 == (0xc0 & s[2])) {
-        return (utf8_t *)s;
+        return (utf8_int8_t *)s;
       }
 
       // ensure that the top 4 bits of this 2-byte utf8
       // codepoint were not 0, as then we could have used
       // one of the smaller encodings
       if (0 == (0x1e & s[0])) {
-        return (utf8_t *)s;
+        return (utf8_int8_t *)s;
       }
 
       // 2-byte utf8 code point (began with 0b110xxxxx)
@@ -1092,17 +1082,17 @@ utf8_constexpr14 utf8_t *utf8nvalid(const utf8_t *str, size_t n) {
       s += 1;
     } else {
       // we have an invalid 0b1xxxxxxx utf8 code point entry
-      return (utf8_t *)s;
+      return (utf8_int8_t *)s;
     }
   }
 
   return utf8_null;
 }
 
-int utf8makevalid(utf8_t *str, const utf8_int32_t replacement) {
-  utf8_t_ *read = (utf8_t_ *)str;
-  utf8_t_ *write = read;
-  const utf8_t_ r = (utf8_t_) replacement;
+int utf8makevalid(utf8_int8_t *str, const utf8_int32_t replacement) {
+  utf8_int8_t *read = (utf8_int8_t *)str;
+  utf8_int8_t *write = read;
+  const utf8_int8_t r = (utf8_int8_t) replacement;
   utf8_int32_t codepoint = 0;
 
   if (replacement > 0x7f) {
@@ -1121,8 +1111,8 @@ int utf8makevalid(utf8_t *str, const utf8_int32_t replacement) {
       }
 
       // 4-byte utf8 code point (began with 0b11110xxx)
-      read = (utf8_t_ *)utf8codepoint(read, &codepoint);
-      write = (utf8_t_ *)utf8catcodepoint(write, codepoint, 4);
+      read = (utf8_int8_t *)utf8codepoint(read, &codepoint);
+      write = (utf8_int8_t *)utf8catcodepoint(write, codepoint, 4);
     } else if (0xe0 == (0xf0 & *read)) {
       // ensure each of the 2 following bytes in this 3-byte
       // utf8 codepoint began with 0b10xxxxxx
@@ -1133,8 +1123,8 @@ int utf8makevalid(utf8_t *str, const utf8_int32_t replacement) {
       }
 
       // 3-byte utf8 code point (began with 0b1110xxxx)
-      read = (utf8_t_ *)utf8codepoint(read, &codepoint);
-      write = (utf8_t_ *)utf8catcodepoint(write, codepoint, 3);
+      read = (utf8_int8_t *)utf8codepoint(read, &codepoint);
+      write = (utf8_int8_t *)utf8catcodepoint(write, codepoint, 3);
     } else if (0xc0 == (0xe0 & *read)) {
       // ensure the 1 following byte in this 2-byte
       // utf8 codepoint began with 0b10xxxxxx
@@ -1145,12 +1135,12 @@ int utf8makevalid(utf8_t *str, const utf8_int32_t replacement) {
       }
 
       // 2-byte utf8 code point (began with 0b110xxxxx)
-      read = (utf8_t_ *)utf8codepoint(read, &codepoint);
-      write = (utf8_t_ *)utf8catcodepoint(write, codepoint, 2);
+      read = (utf8_int8_t *)utf8codepoint(read, &codepoint);
+      write = (utf8_int8_t *)utf8catcodepoint(write, codepoint, 2);
     } else if (0x00 == (0x80 & *read)) {
       // 1-byte ascii (began with 0b0xxxxxxx)
-      read = (utf8_t_ *)utf8codepoint(read, &codepoint);
-      write = (utf8_t_ *)utf8catcodepoint(write, codepoint, 1);
+      read = (utf8_int8_t *)utf8codepoint(read, &codepoint);
+      write = (utf8_int8_t *)utf8catcodepoint(write, codepoint, 1);
     } else {
       // if we got here then we've got a dangling continuation (0b10xxxxxx)
       *write++ = r;
@@ -1164,9 +1154,9 @@ int utf8makevalid(utf8_t *str, const utf8_int32_t replacement) {
   return 0;
 }
 
-utf8_constexpr14 utf8_t *utf8codepoint(const utf8_t *utf8_restrict str,
+utf8_constexpr14 utf8_int8_t *utf8codepoint(const utf8_int8_t *utf8_restrict str,
                                      utf8_int32_t *utf8_restrict out_codepoint) {
-  const utf8_t_ *s = (const utf8_t_ *)str;
+  const utf8_int8_t *s = (const utf8_int8_t *)str;
 
   if (0xf0 == (0xf8 & s[0])) {
     // 4 byte utf8 codepoint
@@ -1188,11 +1178,11 @@ utf8_constexpr14 utf8_t *utf8codepoint(const utf8_t *utf8_restrict str,
     s += 1;
   }
 
-  return (utf8_t *)s;
+  return (utf8_int8_t *)s;
 }
 
-utf8_constexpr14 size_t utf8codepointcalcsize(const utf8_t *str) {
-  const utf8_t_ *s = (const utf8_t_ *)str;
+utf8_constexpr14 size_t utf8codepointcalcsize(const utf8_int8_t *str) {
+  const utf8_int8_t *s = (const utf8_int8_t *)str;
 
   if (0xf0 == (0xf8 & s[0])) {
     // 4 byte utf8 codepoint
@@ -1221,8 +1211,8 @@ utf8_constexpr14 size_t utf8codepointsize(utf8_int32_t chr) {
   }
 }
 
-utf8_t *utf8catcodepoint(utf8_t *str, utf8_int32_t chr, size_t n) {
-  utf8_t_ *s = (utf8_t_ *)str;
+utf8_int8_t *utf8catcodepoint(utf8_int8_t *str, utf8_int32_t chr, size_t n) {
+  utf8_int8_t *s = (utf8_int8_t *)str;
 
   if (0 == ((utf8_int32_t)0xffffff80 & chr)) {
     // 1-byte/7-bit ascii
@@ -1230,7 +1220,7 @@ utf8_t *utf8catcodepoint(utf8_t *str, utf8_int32_t chr, size_t n) {
     if (n < 1) {
       return utf8_null;
     }
-    s[0] = (utf8_t_) chr;
+    s[0] = (utf8_int8_t) chr;
     s += 1;
   } else if (0 == ((utf8_int32_t)0xfffff800 & chr)) {
     // 2-byte/11-bit utf8 code point
@@ -1238,8 +1228,8 @@ utf8_t *utf8catcodepoint(utf8_t *str, utf8_int32_t chr, size_t n) {
     if (n < 2) {
       return utf8_null;
     }
-    s[0] = (utf8_t_)  (0xc0 | (utf8_t_) ((chr >> 6) & 0x1f));
-    s[1] = (utf8_t_)  (0x80 | (utf8_t_) (chr & 0x3f));
+    s[0] = (utf8_int8_t)  (0xc0 | (utf8_int8_t) ((chr >> 6) & 0x1f));
+    s[1] = (utf8_int8_t)  (0x80 | (utf8_int8_t) (chr & 0x3f));
     s += 2;
   } else if (0 == ((utf8_int32_t)0xffff0000 & chr)) {
     // 3-byte/16-bit utf8 code point
@@ -1247,9 +1237,9 @@ utf8_t *utf8catcodepoint(utf8_t *str, utf8_int32_t chr, size_t n) {
     if (n < 3) {
       return utf8_null;
     }
-    s[0] = (utf8_t_)  (0xe0 | (utf8_t_) ((chr >> 12) & 0x0f));
-    s[1] = (utf8_t_)  (0x80 | (utf8_t_) ((chr >> 6) & 0x3f));
-    s[2] = (utf8_t_)  (0x80 | (utf8_t_) (chr & 0x3f));
+    s[0] = (utf8_int8_t)  (0xe0 | (utf8_int8_t) ((chr >> 12) & 0x0f));
+    s[1] = (utf8_int8_t)  (0x80 | (utf8_int8_t) ((chr >> 6) & 0x3f));
+    s[2] = (utf8_int8_t)  (0x80 | (utf8_int8_t) (chr & 0x3f));
     s += 3;
   } else { // if (0 == ((int)0xffe00000 & chr)) {
     // 4-byte/21-bit utf8 code point
@@ -1257,10 +1247,10 @@ utf8_t *utf8catcodepoint(utf8_t *str, utf8_int32_t chr, size_t n) {
     if (n < 4) {
       return utf8_null;
     }
-    s[0] = (utf8_t_)  (0xf0 | (utf8_t_) ((chr >> 18) & 0x07));
-    s[1] = (utf8_t_)  (0x80 | (utf8_t_) ((chr >> 12) & 0x3f));
-    s[2] = (utf8_t_)  (0x80 | (utf8_t_) ((chr >> 6) & 0x3f));
-    s[3] = (utf8_t_)  (0x80 | (utf8_t_) (chr & 0x3f));
+    s[0] = (utf8_int8_t)  (0xf0 | (utf8_int8_t) ((chr >> 18) & 0x07));
+    s[1] = (utf8_int8_t)  (0x80 | (utf8_int8_t) ((chr >> 12) & 0x3f));
+    s[2] = (utf8_int8_t)  (0x80 | (utf8_int8_t) ((chr >> 6) & 0x3f));
+    s[3] = (utf8_int8_t)  (0x80 | (utf8_int8_t) (chr & 0x3f));
     s += 4;
   }
 
@@ -1271,11 +1261,11 @@ utf8_constexpr14 int utf8islower(utf8_int32_t chr) { return chr != utf8uprcodepo
 
 utf8_constexpr14 int utf8isupper(utf8_int32_t chr) { return chr != utf8lwrcodepoint(chr); }
 
-void utf8lwr(utf8_t *utf8_restrict str) {
-  utf8_t *p = utf8_null, *pn = utf8_null;
+void utf8lwr(utf8_int8_t *utf8_restrict str) {
+  utf8_int8_t *p = utf8_null, *pn = utf8_null;
   utf8_int32_t cp = 0;
 
-  p = (utf8_t_ *)str;
+  p = (utf8_int8_t *)str;
   pn = utf8codepoint(p, &cp);
 
   while (cp != 0) {
@@ -1291,11 +1281,11 @@ void utf8lwr(utf8_t *utf8_restrict str) {
   }
 }
 
-void utf8upr(utf8_t *utf8_restrict str) {
-  utf8_t *p = utf8_null, *pn = utf8_null;
+void utf8upr(utf8_int8_t *utf8_restrict str) {
+  utf8_int8_t *p = utf8_null, *pn = utf8_null;
   utf8_int32_t cp = 0;
 
-  p = (utf8_t_ *)str;
+  p = (utf8_int8_t *)str;
   pn = utf8codepoint(p, &cp);
 
   while (cp != 0) {
@@ -1643,9 +1633,9 @@ utf8_constexpr14 utf8_int32_t utf8uprcodepoint(utf8_int32_t cp) {
   return cp;
 }
 
-utf8_constexpr14 utf8_t *utf8rcodepoint(const utf8_t *utf8_restrict str,
+utf8_constexpr14 utf8_int8_t *utf8rcodepoint(const utf8_int8_t *utf8_restrict str,
                      utf8_int32_t *utf8_restrict out_codepoint) {
-  const utf8_t_ *s = (const utf8_t_ *)str;
+  const utf8_int8_t *s = (const utf8_int8_t *)str;
 
   if (0xf0 == (0xf8 & s[0])) {
     // 4 byte utf8 codepoint
@@ -1667,7 +1657,7 @@ utf8_constexpr14 utf8_t *utf8rcodepoint(const utf8_t *utf8_restrict str,
     s--;
   } while ((0 != (0x80 & s[0])) && (0x80 == (0xc0 & s[0])));
 
-  return (utf8_t *)s;
+  return (utf8_int8_t *)s;
 }
 
 #undef utf8_restrict

--- a/utf8.h
+++ b/utf8.h
@@ -87,23 +87,29 @@ extern "C" {
 #define utf8_null 0
 #endif
 
+#if defined(__cplusplus) && __cplusplus >= 201402L
+#define utf8_constexpr14 constexpr
+#else
+#define utf8_constexpr14
+#endif
+
 // Return less than 0, 0, greater than 0 if src1 < src2, src1 == src2, src1 >
 // src2 respectively, case insensitive.
-utf8_nonnull utf8_pure utf8_weak int utf8casecmp(const void *src1,
-                                                 const void *src2);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak int utf8casecmp(const void *src1,
+                                                                  const void *src2);
 
 // Append the utf8 string src onto the utf8 string dst.
 utf8_nonnull utf8_weak void *utf8cat(void *utf8_restrict dst,
                                      const void *utf8_restrict src);
 
 // Find the first match of the utf8 codepoint chr in the utf8 string src.
-utf8_nonnull utf8_pure utf8_weak void *utf8chr(const void *src,
-                                               utf8_int32_t chr);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak void *utf8chr(const void *src,
+                                                                utf8_int32_t chr);
 
 // Return less than 0, 0, greater than 0 if src1 < src2,
 // src1 == src2, src1 > src2 respectively.
-utf8_nonnull utf8_pure utf8_weak int utf8cmp(const void *src1,
-                                             const void *src2);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak int utf8cmp(const void *src1,
+                                                              const void *src2);
 
 // Copy the utf8 string src onto the memory allocated in dst.
 utf8_nonnull utf8_weak void *utf8cpy(void *utf8_restrict dst,
@@ -111,8 +117,8 @@ utf8_nonnull utf8_weak void *utf8cpy(void *utf8_restrict dst,
 
 // Number of utf8 codepoints in the utf8 string src that consists entirely
 // of utf8 codepoints not from the utf8 string reject.
-utf8_nonnull utf8_pure utf8_weak size_t utf8cspn(const void *src,
-                                                 const void *reject);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak size_t utf8cspn(const void *src,
+                                                                  const void *reject);
 
 // Duplicate the utf8 string src by getting its size, malloc'ing a new buffer
 // copying over the data, and returning that. Or 0 if malloc failed.
@@ -120,16 +126,16 @@ utf8_weak void *utf8dup(const void *src);
 
 // Number of utf8 codepoints in the utf8 string str,
 // excluding the null terminating byte.
-utf8_nonnull utf8_pure utf8_weak size_t utf8len(const void *str);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak size_t utf8len(const void *str);
 
 // Similar to utf8len, except that only at most n bytes of src are looked.
-utf8_nonnull utf8_pure utf8_weak size_t utf8nlen(const void *str, size_t n);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak size_t utf8nlen(const void *str, size_t n);
 
 // Return less than 0, 0, greater than 0 if src1 < src2, src1 == src2, src1 >
 // src2 respectively, case insensitive. Checking at most n bytes of each utf8
 // string.
-utf8_nonnull utf8_pure utf8_weak int utf8ncasecmp(const void *src1,
-                                                  const void *src2, size_t n);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak int utf8ncasecmp(const void *src1,
+                                                                   const void *src2, size_t n);
 
 // Append the utf8 string src onto the utf8 string dst,
 // writing at most n+1 bytes. Can produce an invalid utf8
@@ -140,8 +146,8 @@ utf8_nonnull utf8_weak void *utf8ncat(void *utf8_restrict dst,
 // Return less than 0, 0, greater than 0 if src1 < src2,
 // src1 == src2, src1 > src2 respectively. Checking at most n
 // bytes of each utf8 string.
-utf8_nonnull utf8_pure utf8_weak int utf8ncmp(const void *src1,
-                                              const void *src2, size_t n);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak int utf8ncmp(const void *src1,
+                                                               const void *src2, size_t n);
 
 // Copy the utf8 string src onto the memory allocated in dst.   
 // Copies at most n bytes. If n falls partway through a utf8
@@ -160,43 +166,43 @@ utf8_weak void *utf8ndup(const void *src, size_t n);
 
 // Locates the first occurrence in the utf8 string str of any byte in the
 // utf8 string accept, or 0 if no match was found.
-utf8_nonnull utf8_pure utf8_weak void *utf8pbrk(const void *str,
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak void *utf8pbrk(const void *str,
                                                 const void *accept);
 
 // Find the last match of the utf8 codepoint chr in the utf8 string src.
-utf8_nonnull utf8_pure utf8_weak void *utf8rchr(const void *src, int chr);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak void *utf8rchr(const void *src, int chr);
 
 // Number of bytes in the utf8 string str,
 // including the null terminating byte.
-utf8_nonnull utf8_pure utf8_weak size_t utf8size(const void *str);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak size_t utf8size(const void *str);
 
 // Similar to utf8size, except that the null terminating byte is excluded.
-utf8_nonnull utf8_pure utf8_weak size_t utf8size_lazy(const void *str);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak size_t utf8size_lazy(const void *str);
 
 // Similar to utf8size, except that only at most n bytes of src are looked and
 // the null terminating byte is excluded.
-utf8_nonnull utf8_pure utf8_weak size_t utf8nsize_lazy(const void *str, size_t n);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak size_t utf8nsize_lazy(const void *str, size_t n);
 
 // Number of utf8 codepoints in the utf8 string src that consists entirely
 // of utf8 codepoints from the utf8 string accept.
-utf8_nonnull utf8_pure utf8_weak size_t utf8spn(const void *src,
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak size_t utf8spn(const void *src,
                                                 const void *accept);
 
 // The position of the utf8 string needle in the utf8 string haystack.
-utf8_nonnull utf8_pure utf8_weak void *utf8str(const void *haystack,
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak void *utf8str(const void *haystack,
                                                const void *needle);
 
 // The position of the utf8 string needle in the utf8 string haystack, case
 // insensitive.
-utf8_nonnull utf8_pure utf8_weak void *utf8casestr(const void *haystack,
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak void *utf8casestr(const void *haystack,
                                                    const void *needle);
 
 // Return 0 on success, or the position of the invalid
 // utf8 codepoint on failure.
-utf8_nonnull utf8_pure utf8_weak void *utf8valid(const void *str);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak void *utf8valid(const void *str);
 
 // Similar to utf8valid, except that only at most n bytes of src are looked.
-utf8_nonnull utf8_pure utf8_weak void *utf8nvalid(const void *str, size_t n);
+utf8_constexpr14 utf8_nonnull utf8_pure utf8_weak void *utf8nvalid(const void *str, size_t n);
 
 // Given a null-terminated string, makes the string valid by replacing invalid
 // codepoints with a 1-byte replacement. Returns 0 on success.
@@ -205,15 +211,15 @@ utf8_nonnull utf8_weak int utf8makevalid(void *str,
 
 // Sets out_codepoint to the current utf8 codepoint in str, and returns the
 // address of the next utf8 codepoint after the current one in str.
-utf8_nonnull utf8_weak void *
+utf8_constexpr14 utf8_nonnull utf8_weak void *
 utf8codepoint(const void *utf8_restrict str,
               utf8_int32_t *utf8_restrict out_codepoint);
 
 // Calculates the size of the next utf8 codepoint in str.
-utf8_nonnull utf8_weak size_t utf8codepointcalcsize(const void *str);
+utf8_constexpr14 utf8_nonnull utf8_weak size_t utf8codepointcalcsize(const void *str);
 
 // Returns the size of the given codepoint in bytes.
-utf8_weak size_t utf8codepointsize(utf8_int32_t chr);
+utf8_constexpr14 utf8_weak size_t utf8codepointsize(utf8_int32_t chr);
 
 // Write a codepoint to the given string, and return the address to the next
 // place after the written codepoint. Pass how many bytes left in the buffer to
@@ -223,10 +229,10 @@ utf8_nonnull utf8_weak void *utf8catcodepoint(void *str, utf8_int32_t chr,
                                               size_t n);
 
 // Returns 1 if the given character is lowercase, or 0 if it is not.
-utf8_weak int utf8islower(utf8_int32_t chr);
+utf8_constexpr14 utf8_weak int utf8islower(utf8_int32_t chr);
 
 // Returns 1 if the given character is uppercase, or 0 if it is not.
-utf8_weak int utf8isupper(utf8_int32_t chr);
+utf8_constexpr14 utf8_weak int utf8isupper(utf8_int32_t chr);
 
 // Transform the given string into all lowercase codepoints.
 utf8_nonnull utf8_weak void utf8lwr(void *utf8_restrict str);
@@ -235,14 +241,14 @@ utf8_nonnull utf8_weak void utf8lwr(void *utf8_restrict str);
 utf8_nonnull utf8_weak void utf8upr(void *utf8_restrict str);
 
 // Make a codepoint lower case if possible.
-utf8_weak utf8_int32_t utf8lwrcodepoint(utf8_int32_t cp);
+utf8_constexpr14 utf8_weak utf8_int32_t utf8lwrcodepoint(utf8_int32_t cp);
 
 // Make a codepoint upper case if possible.
-utf8_weak utf8_int32_t utf8uprcodepoint(utf8_int32_t cp);
+utf8_constexpr14 utf8_weak utf8_int32_t utf8uprcodepoint(utf8_int32_t cp);
 
 // Sets out_codepoint to the current utf8 codepoint in str, and returns the
 // address of the previous utf8 codepoint before the current one in str.
-utf8_nonnull utf8_weak void *
+utf8_constexpr14 utf8_nonnull utf8_weak void *
 utf8rcodepoint(const void *utf8_restrict str,
                utf8_int32_t *utf8_restrict out_codepoint);
 
@@ -265,9 +271,9 @@ utf8_weak void *utf8ndup_ex(const void *src, size_t n,
 #undef utf8_pure
 #undef utf8_nonnull
 
-int utf8casecmp(const void *src1, const void *src2) {
-  utf8_int32_t src1_lwr_cp, src2_lwr_cp, src1_upr_cp, src2_upr_cp, src1_orig_cp,
-      src2_orig_cp;
+utf8_constexpr14 int utf8casecmp(const void *src1, const void *src2) {
+  utf8_int32_t src1_lwr_cp = 0, src2_lwr_cp = 0, src1_upr_cp = 0,
+        src2_upr_cp = 0, src1_orig_cp = 0, src2_orig_cp = 0;
 
   for (;;) {
     src1 = utf8codepoint(src1, &src1_orig_cp);
@@ -313,7 +319,7 @@ void *utf8cat(void *utf8_restrict dst, const void *utf8_restrict src) {
   return dst;
 }
 
-void *utf8chr(const void *src, utf8_int32_t chr) {
+utf8_constexpr14 void *utf8chr(const void *src, utf8_int32_t chr) {
   char c[5] = {'\0', '\0', '\0', '\0', '\0'};
 
   if (0 == chr) {
@@ -354,7 +360,7 @@ void *utf8chr(const void *src, utf8_int32_t chr) {
   return utf8str(src, c);
 }
 
-int utf8cmp(const void *src1, const void *src2) {
+utf8_constexpr14 int utf8cmp(const void *src1, const void *src2) {
   const unsigned char *s1 = (const unsigned char *)src1;
   const unsigned char *s2 = (const unsigned char *)src2;
 
@@ -373,7 +379,7 @@ int utf8cmp(const void *src1, const void *src2) {
   return 0;
 }
 
-int utf8coll(const void *src1, const void *src2);
+utf8_constexpr14 int utf8coll(const void *src1, const void *src2);
 
 void *utf8cpy(void *utf8_restrict dst, const void *utf8_restrict src) {
   char *d = (char *)dst;
@@ -391,7 +397,7 @@ void *utf8cpy(void *utf8_restrict dst, const void *utf8_restrict src) {
   return dst;
 }
 
-size_t utf8cspn(const void *src, const void *reject) {
+utf8_constexpr14 size_t utf8cspn(const void *src, const void *reject) {
   const char *s = (const char *)src;
   size_t chars = 0;
 
@@ -445,7 +451,7 @@ size_t utf8cspn(const void *src, const void *reject) {
 void *utf8dup(const void *src) { return utf8dup_ex(src, utf8_null, utf8_null); }
 
 void *utf8dup_ex(const void *src, void *(*alloc_func_ptr)(void *, size_t),
-                 void *user_data) {
+                                  void *user_data) {
   const char *s = (const char *)src;
   char *n = utf8_null;
 
@@ -476,13 +482,13 @@ void *utf8dup_ex(const void *src, void *(*alloc_func_ptr)(void *, size_t),
   }
 }
 
-void *utf8fry(const void *str);
+utf8_constexpr14 void *utf8fry(const void *str);
 
-size_t utf8len(const void *str) {
+utf8_constexpr14 size_t utf8len(const void *str) {
   return utf8nlen(str, SIZE_MAX);
 }
 
-size_t utf8nlen(const void *str, size_t n) {
+utf8_constexpr14 size_t utf8nlen(const void *str, size_t n) {
   const unsigned char *s = (const unsigned char *)str;
   const unsigned char *t = s;
   size_t length = 0;
@@ -513,9 +519,9 @@ size_t utf8nlen(const void *str, size_t n) {
   return length;
 }
 
-int utf8ncasecmp(const void *src1, const void *src2, size_t n) {
-  utf8_int32_t src1_lwr_cp, src2_lwr_cp, src1_upr_cp, src2_upr_cp, src1_orig_cp,
-      src2_orig_cp;
+utf8_constexpr14 int utf8ncasecmp(const void *src1, const void *src2, size_t n) {
+  utf8_int32_t src1_lwr_cp = 0, src2_lwr_cp = 0, src1_upr_cp = 0, src2_upr_cp = 0,
+        src1_orig_cp = 0, src2_orig_cp = 0;
 
   do {
     const unsigned char *const s1 = (const unsigned char *)src1;
@@ -607,7 +613,7 @@ void *utf8ncat(void *utf8_restrict dst, const void *utf8_restrict src,
   return dst;
 }
 
-int utf8ncmp(const void *src1, const void *src2, size_t n) {
+utf8_constexpr14 int utf8ncmp(const void *src1, const void *src2, size_t n) {
   const unsigned char *s1 = (const unsigned char *)src1;
   const unsigned char *s2 = (const unsigned char *)src2;
 
@@ -630,7 +636,7 @@ void *utf8ncpy(void *utf8_restrict dst, const void *utf8_restrict src,
                size_t n) {
   char *d = (char *)dst;
   const char *s = (const char *)src;
-  size_t index, check_index;
+  size_t index = 0, check_index = 0;
 
   if (n == 0) {
     return dst;
@@ -704,7 +710,7 @@ void *utf8ndup_ex(const void *src, size_t n,
   return c;
 }
 
-void *utf8rchr(const void *src, int chr) {
+utf8_constexpr14 void *utf8rchr(const void *src, int chr) {
   const char *s = (const char *)src;
   const char *match = utf8_null;
   char c[5] = {'\0', '\0', '\0', '\0', '\0'};
@@ -772,7 +778,7 @@ void *utf8rchr(const void *src, int chr) {
   return (void *)match;
 }
 
-void *utf8pbrk(const void *str, const void *accept) {
+utf8_constexpr14 void *utf8pbrk(const void *str, const void *accept) {
   const char *s = (const char *)str;
 
   while ('\0' != *s) {
@@ -821,15 +827,15 @@ void *utf8pbrk(const void *str, const void *accept) {
   return utf8_null;
 }
 
-size_t utf8size(const void *str) {
+utf8_constexpr14 size_t utf8size(const void *str) {
   return utf8size_lazy(str) + 1;
 }
 
-size_t utf8size_lazy(const void *str) {
+utf8_constexpr14 size_t utf8size_lazy(const void *str) {
   return utf8nsize_lazy(str, SIZE_MAX);
 }
 
-size_t utf8nsize_lazy(const void *str, size_t n) {
+utf8_constexpr14 size_t utf8nsize_lazy(const void *str, size_t n) {
   const char *s = (const char *)str;
   size_t size = 0;
   while (size < n && '\0' != s[size]) {
@@ -838,7 +844,7 @@ size_t utf8nsize_lazy(const void *str, size_t n) {
   return size;
 }
 
-size_t utf8spn(const void *src, const void *accept) {
+utf8_constexpr14 size_t utf8spn(const void *src, const void *accept) {
   const char *s = (const char *)src;
   size_t chars = 0;
 
@@ -892,9 +898,9 @@ size_t utf8spn(const void *src, const void *accept) {
   return chars;
 }
 
-void *utf8str(const void *haystack, const void *needle) {
+utf8_constexpr14 void *utf8str(const void *haystack, const void *needle) {
   const char *h = (const char *)haystack;
-  utf8_int32_t throwaway_codepoint;
+  utf8_int32_t throwaway_codepoint = 0;
 
   // if needle has no utf8 codepoints before the null terminating
   // byte then return haystack
@@ -927,7 +933,7 @@ void *utf8str(const void *haystack, const void *needle) {
   return utf8_null;
 }
 
-void *utf8casestr(const void *haystack, const void *needle) {
+utf8_constexpr14 void *utf8casestr(const void *haystack, const void *needle) {
   const void *h = haystack;
 
   // if needle has no utf8 codepoints before the null terminating
@@ -939,7 +945,7 @@ void *utf8casestr(const void *haystack, const void *needle) {
   for (;;) {
     const void *maybeMatch = h;
     const void *n = needle;
-    utf8_int32_t h_cp, n_cp;
+    utf8_int32_t h_cp = 0, n_cp = 0;
 
     // Get the next code point and track it
     const void *nextH = h = utf8codepoint(h, &h_cp);
@@ -974,14 +980,14 @@ void *utf8casestr(const void *haystack, const void *needle) {
   }
 }
 
-void *utf8valid(const void *str) {
+utf8_constexpr14 void *utf8valid(const void *str) {
   return utf8nvalid(str, SIZE_MAX);
 }
 
-void *utf8nvalid(const void *str, size_t n) {
+utf8_constexpr14 void *utf8nvalid(const void *str, size_t n) {
   const char *s = (const char *)str;
   const char *t = s;
-  size_t consumed, remained;
+  size_t consumed = 0, remained = 0;
 
   while ((void) (consumed = (size_t) (s-t)), consumed < n && '\0' != *s) {
     remained = n - consumed;
@@ -1081,7 +1087,7 @@ int utf8makevalid(void *str, const utf8_int32_t replacement) {
   char *read = (char *)str;
   char *write = read;
   const char r = (char)replacement;
-  utf8_int32_t codepoint;
+  utf8_int32_t codepoint = 0;
 
   if (replacement > 0x7f) {
     return -1;
@@ -1142,8 +1148,8 @@ int utf8makevalid(void *str, const utf8_int32_t replacement) {
   return 0;
 }
 
-void *utf8codepoint(const void *utf8_restrict str,
-                    utf8_int32_t *utf8_restrict out_codepoint) {
+utf8_constexpr14 void *utf8codepoint(const void *utf8_restrict str,
+                                     utf8_int32_t *utf8_restrict out_codepoint) {
   const char *s = (const char *)str;
 
   if (0xf0 == (0xf8 & s[0])) {
@@ -1169,7 +1175,7 @@ void *utf8codepoint(const void *utf8_restrict str,
   return (void *)s;
 }
 
-size_t utf8codepointcalcsize(const void *str) {
+utf8_constexpr14 size_t utf8codepointcalcsize(const void *str) {
   const char *s = (const char *)str;
 
   if (0xf0 == (0xf8 & s[0])) {
@@ -1187,7 +1193,7 @@ size_t utf8codepointcalcsize(const void *str) {
   return 1;
 }
 
-size_t utf8codepointsize(utf8_int32_t chr) {
+utf8_constexpr14 size_t utf8codepointsize(utf8_int32_t chr) {
   if (0 == ((utf8_int32_t)0xffffff80 & chr)) {
     return 1;
   } else if (0 == ((utf8_int32_t)0xfffff800 & chr)) {
@@ -1245,13 +1251,13 @@ void *utf8catcodepoint(void *str, utf8_int32_t chr, size_t n) {
   return s;
 }
 
-int utf8islower(utf8_int32_t chr) { return chr != utf8uprcodepoint(chr); }
+utf8_constexpr14 int utf8islower(utf8_int32_t chr) { return chr != utf8uprcodepoint(chr); }
 
-int utf8isupper(utf8_int32_t chr) { return chr != utf8lwrcodepoint(chr); }
+utf8_constexpr14 int utf8isupper(utf8_int32_t chr) { return chr != utf8lwrcodepoint(chr); }
 
 void utf8lwr(void *utf8_restrict str) {
-  void *p, *pn;
-  utf8_int32_t cp;
+  void *p = utf8_null, *pn = utf8_null;
+  utf8_int32_t cp = 0;
 
   p = (char *)str;
   pn = utf8codepoint(p, &cp);
@@ -1270,8 +1276,8 @@ void utf8lwr(void *utf8_restrict str) {
 }
 
 void utf8upr(void *utf8_restrict str) {
-  void *p, *pn;
-  utf8_int32_t cp;
+  void *p = utf8_null, *pn = utf8_null;
+  utf8_int32_t cp = 0;
 
   p = (char *)str;
   pn = utf8codepoint(p, &cp);
@@ -1289,7 +1295,7 @@ void utf8upr(void *utf8_restrict str) {
   }
 }
 
-utf8_int32_t utf8lwrcodepoint(utf8_int32_t cp) {
+utf8_constexpr14 utf8_int32_t utf8lwrcodepoint(utf8_int32_t cp) {
   if (((0x0041 <= cp) && (0x005a >= cp)) ||
       ((0x00c0 <= cp) && (0x00d6 >= cp)) ||
       ((0x00d8 <= cp) && (0x00de >= cp)) ||
@@ -1455,7 +1461,7 @@ utf8_int32_t utf8lwrcodepoint(utf8_int32_t cp) {
   return cp;
 }
 
-utf8_int32_t utf8uprcodepoint(utf8_int32_t cp) {
+utf8_constexpr14 utf8_int32_t utf8uprcodepoint(utf8_int32_t cp) {
   if (((0x0061 <= cp) && (0x007a >= cp)) ||
       ((0x00e0 <= cp) && (0x00f6 >= cp)) ||
       ((0x00f8 <= cp) && (0x00fe >= cp)) ||
@@ -1621,7 +1627,7 @@ utf8_int32_t utf8uprcodepoint(utf8_int32_t cp) {
   return cp;
 }
 
-void *utf8rcodepoint(const void *utf8_restrict str,
+utf8_constexpr14 void *utf8rcodepoint(const void *utf8_restrict str,
                      utf8_int32_t *utf8_restrict out_codepoint) {
   const char *s = (const char *)str;
 
@@ -1649,6 +1655,7 @@ void *utf8rcodepoint(const void *utf8_restrict str,
 }
 
 #undef utf8_restrict
+#undef utf8_constexpr14
 #undef utf8_null
 
 #ifdef __cplusplus

--- a/utf8.h
+++ b/utf8.h
@@ -370,8 +370,8 @@ utf8_constexpr14 utf8_t *utf8chr(const utf8_t *src, utf8_int32_t chr) {
 }
 
 utf8_constexpr14 int utf8cmp(const utf8_t *src1, const utf8_t *src2) {
-  const unsigned char *s1 = (const unsigned char *)src1;
-  const unsigned char *s2 = (const unsigned char *)src2;
+  const char *s1 = (const char *)src1;
+  const char *s2 = (const char *)src2;
 
   while (('\0' != *s1) || ('\0' != *s2)) {
     if (*s1 < *s2) {
@@ -498,8 +498,8 @@ utf8_constexpr14 size_t utf8len(const utf8_t *str) {
 }
 
 utf8_constexpr14 size_t utf8nlen(const utf8_t *str, size_t n) {
-  const unsigned char *s = (const unsigned char *)str;
-  const unsigned char *t = s;
+  const char *s = (const char *)str;
+  const char *t = s;
   size_t length = 0;
 
   while ((size_t) (s-t) < n && '\0' != *s) {
@@ -533,8 +533,8 @@ utf8_constexpr14 int utf8ncasecmp(const utf8_t *src1, const utf8_t *src2, size_t
         src1_orig_cp = 0, src2_orig_cp = 0;
 
   do {
-    const unsigned char *const s1 = (const unsigned char *)src1;
-    const unsigned char *const s2 = (const unsigned char *)src2;
+    const char *const s1 = (const char *)src1;
+    const char *const s2 = (const char *)src2;
 
     // first check that we have enough bytes left in n to contain an entire
     // codepoint
@@ -623,8 +623,8 @@ utf8_t *utf8ncat(utf8_t *utf8_restrict dst, const utf8_t *utf8_restrict src,
 }
 
 utf8_constexpr14 int utf8ncmp(const utf8_t *src1, const utf8_t *src2, size_t n) {
-  const unsigned char *s1 = (const unsigned char *)src1;
-  const unsigned char *s2 = (const unsigned char *)src2;
+  const char *s1 = (const char *)src1;
+  const char *s2 = (const char *)src2;
 
   while ((0 != n--) && (('\0' != *s1) || ('\0' != *s2))) {
     if (*s1 < *s2) {

--- a/utf8.h
+++ b/utf8.h
@@ -101,6 +101,13 @@ using utf8_t = char; // constexpr does not allow cast from void *
 typedef void utf8_t;
 #endif
 
+// Internal type
+#if defined(__cplusplus) && __cplusplus >= 202002L
+using utf8_t_ = char8_t; // Introduced in C++20
+#else
+typedef char utf8_t_;
+#endif
+
 
 // Return less than 0, 0, greater than 0 if src1 < src2, src1 == src2, src1 >
 // src2 respectively, case insensitive.
@@ -309,8 +316,8 @@ utf8_constexpr14 int utf8casecmp(const utf8_t *src1, const utf8_t *src2) {
 }
 
 utf8_t *utf8cat(utf8_t *utf8_restrict dst, const utf8_t *utf8_restrict src) {
-  char *d = (char *)dst;
-  const char *s = (const char *)src;
+  utf8_t_ *d = (utf8_t_ *)dst;
+  const utf8_t_ *s = (const utf8_t_ *)src;
 
   // find the null terminating byte in dst
   while ('\0' != *d) {
@@ -329,12 +336,12 @@ utf8_t *utf8cat(utf8_t *utf8_restrict dst, const utf8_t *utf8_restrict src) {
 }
 
 utf8_constexpr14 utf8_t *utf8chr(const utf8_t *src, utf8_int32_t chr) {
-  char c[5] = {'\0', '\0', '\0', '\0', '\0'};
+  utf8_t_ c[5] = {'\0', '\0', '\0', '\0', '\0'};
 
   if (0 == chr) {
     // being asked to return position of null terminating byte, so
     // just run s to the end, and return!
-    const char *s = (const char *)src;
+    const utf8_t_ *s = (const utf8_t_ *)src;
     while ('\0' != *s) {
       s++;
     }
@@ -342,25 +349,25 @@ utf8_constexpr14 utf8_t *utf8chr(const utf8_t *src, utf8_int32_t chr) {
   } else if (0 == ((utf8_int32_t)0xffffff80 & chr)) {
     // 1-byte/7-bit ascii
     // (0b0xxxxxxx)
-    c[0] = (char)chr;
+    c[0] = (utf8_t_) chr;
   } else if (0 == ((utf8_int32_t)0xfffff800 & chr)) {
     // 2-byte/11-bit utf8 code point
     // (0b110xxxxx 0b10xxxxxx)
-    c[0] = (char) (0xc0 | (char)(chr >> 6));
-    c[1] = (char) (0x80 | (char)(chr & 0x3f));
+    c[0] = (utf8_t_)  (0xc0 | (utf8_t_) (chr >> 6));
+    c[1] = (utf8_t_)  (0x80 | (utf8_t_) (chr & 0x3f));
   } else if (0 == ((utf8_int32_t)0xffff0000 & chr)) {
     // 3-byte/16-bit utf8 code point
     // (0b1110xxxx 0b10xxxxxx 0b10xxxxxx)
-    c[0] = (char) (0xe0 | (char)(chr >> 12));
-    c[1] = (char) (0x80 | (char)((chr >> 6) & 0x3f));
-    c[2] = (char) (0x80 | (char)(chr & 0x3f));
+    c[0] = (utf8_t_)  (0xe0 | (utf8_t_) (chr >> 12));
+    c[1] = (utf8_t_)  (0x80 | (utf8_t_) ((chr >> 6) & 0x3f));
+    c[2] = (utf8_t_)  (0x80 | (utf8_t_) (chr & 0x3f));
   } else { // if (0 == ((int)0xffe00000 & chr)) {
     // 4-byte/21-bit utf8 code point
     // (0b11110xxx 0b10xxxxxx 0b10xxxxxx 0b10xxxxxx)
-    c[0] = (char) (0xf0 | (char)(chr >> 18));
-    c[1] = (char) (0x80 | (char)((chr >> 12) & 0x3f));
-    c[2] = (char) (0x80 | (char)((chr >> 6) & 0x3f));
-    c[3] = (char) (0x80 | (char)(chr & 0x3f));
+    c[0] = (utf8_t_)  (0xf0 | (utf8_t_) (chr >> 18));
+    c[1] = (utf8_t_)  (0x80 | (utf8_t_) ((chr >> 12) & 0x3f));
+    c[2] = (utf8_t_)  (0x80 | (utf8_t_) ((chr >> 6) & 0x3f));
+    c[3] = (utf8_t_)  (0x80 | (utf8_t_) (chr & 0x3f));
   }
 
   // we've made c into a 2 utf8 codepoint string, one for the chr we are
@@ -370,8 +377,8 @@ utf8_constexpr14 utf8_t *utf8chr(const utf8_t *src, utf8_int32_t chr) {
 }
 
 utf8_constexpr14 int utf8cmp(const utf8_t *src1, const utf8_t *src2) {
-  const char *s1 = (const char *)src1;
-  const char *s2 = (const char *)src2;
+  const utf8_t_ *s1 = (const utf8_t_ *)src1;
+  const utf8_t_ *s2 = (const utf8_t_ *)src2;
 
   while (('\0' != *s1) || ('\0' != *s2)) {
     if (*s1 < *s2) {
@@ -391,8 +398,8 @@ utf8_constexpr14 int utf8cmp(const utf8_t *src1, const utf8_t *src2) {
 utf8_constexpr14 int utf8coll(const utf8_t *src1, const utf8_t *src2);
 
 utf8_t *utf8cpy(utf8_t *utf8_restrict dst, const utf8_t *utf8_restrict src) {
-  char *d = (char *)dst;
-  const char *s = (const char *)src;
+  utf8_t_ *d = (utf8_t_ *)dst;
+  const utf8_t_ *s = (const utf8_t_ *)src;
 
   // overwriting anything previously in dst, write byte-by-byte
   // from src
@@ -407,11 +414,11 @@ utf8_t *utf8cpy(utf8_t *utf8_restrict dst, const utf8_t *utf8_restrict src) {
 }
 
 utf8_constexpr14 size_t utf8cspn(const utf8_t *src, const utf8_t *reject) {
-  const char *s = (const char *)src;
+  const utf8_t_ *s = (const utf8_t_ *)src;
   size_t chars = 0;
 
   while ('\0' != *s) {
-    const char *r = (const char *)reject;
+    const utf8_t_ *r = (const utf8_t_ *)reject;
     size_t offset = 0;
 
     while ('\0' != *r) {
@@ -461,16 +468,16 @@ utf8_t *utf8dup(const utf8_t *src) { return utf8dup_ex(src, utf8_null, utf8_null
 
 utf8_t *utf8dup_ex(const utf8_t *src, utf8_t *(*alloc_func_ptr)(utf8_t *, size_t),
                                   utf8_t *user_data) {
-  const char *s = (const char *)src;
-  char *n = utf8_null;
+  const utf8_t_ *s = (const utf8_t_ *)src;
+  utf8_t_ *n = utf8_null;
 
   // figure out how many bytes (including the terminator) we need to copy first
   size_t bytes = utf8size(src);
 
   if (alloc_func_ptr) {
-    n = (char *)alloc_func_ptr(user_data, bytes);
+    n = (utf8_t_ *)alloc_func_ptr(user_data, bytes);
   } else {
-    n = (char *)malloc(bytes);
+    n = (utf8_t_ *)malloc(bytes);
   }
 
   if (utf8_null == n) {
@@ -498,8 +505,8 @@ utf8_constexpr14 size_t utf8len(const utf8_t *str) {
 }
 
 utf8_constexpr14 size_t utf8nlen(const utf8_t *str, size_t n) {
-  const char *s = (const char *)str;
-  const char *t = s;
+  const utf8_t_ *s = (const utf8_t_ *)str;
+  const utf8_t_ *t = s;
   size_t length = 0;
 
   while ((size_t) (s-t) < n && '\0' != *s) {
@@ -533,8 +540,8 @@ utf8_constexpr14 int utf8ncasecmp(const utf8_t *src1, const utf8_t *src2, size_t
         src1_orig_cp = 0, src2_orig_cp = 0;
 
   do {
-    const char *const s1 = (const char *)src1;
-    const char *const s2 = (const char *)src2;
+    const utf8_t_ *const s1 = (const utf8_t_ *)src1;
+    const utf8_t_ *const s2 = (const utf8_t_ *)src2;
 
     // first check that we have enough bytes left in n to contain an entire
     // codepoint
@@ -602,8 +609,8 @@ utf8_constexpr14 int utf8ncasecmp(const utf8_t *src1, const utf8_t *src2, size_t
 
 utf8_t *utf8ncat(utf8_t *utf8_restrict dst, const utf8_t *utf8_restrict src,
                size_t n) {
-  char *d = (char *)dst;
-  const char *s = (const char *)src;
+  utf8_t_ *d = (utf8_t_ *)dst;
+  const utf8_t_ *s = (const utf8_t_ *)src;
 
   // find the null terminating byte in dst
   while ('\0' != *d) {
@@ -623,8 +630,8 @@ utf8_t *utf8ncat(utf8_t *utf8_restrict dst, const utf8_t *utf8_restrict src,
 }
 
 utf8_constexpr14 int utf8ncmp(const utf8_t *src1, const utf8_t *src2, size_t n) {
-  const char *s1 = (const char *)src1;
-  const char *s2 = (const char *)src2;
+  const utf8_t_ *s1 = (const utf8_t_ *)src1;
+  const utf8_t_ *s2 = (const utf8_t_ *)src2;
 
   while ((0 != n--) && (('\0' != *s1) || ('\0' != *s2))) {
     if (*s1 < *s2) {
@@ -643,8 +650,8 @@ utf8_constexpr14 int utf8ncmp(const utf8_t *src1, const utf8_t *src2, size_t n) 
 
 utf8_t *utf8ncpy(utf8_t *utf8_restrict dst, const utf8_t *utf8_restrict src,
                size_t n) {
-  char *d = (char *)dst;
-  const char *s = (const char *)src;
+  utf8_t_ *d = (utf8_t_ *)dst;
+  const utf8_t_ *s = (const utf8_t_ *)src;
   size_t index = 0, check_index = 0;
 
   if (n == 0) {
@@ -682,8 +689,8 @@ utf8_t *utf8ndup(const utf8_t *src, size_t n) {
 
 utf8_t *utf8ndup_ex(const utf8_t *src, size_t n,
                   utf8_t *(*alloc_func_ptr)(utf8_t *, size_t), utf8_t *user_data) {
-  const char *s = (const char *)src;
-  char *c = utf8_null;
+  const utf8_t_ *s = (const utf8_t_ *)src;
+  utf8_t_ *c = utf8_null;
   size_t bytes = 0;
 
   // Find the end of the string or stop when n is reached
@@ -696,9 +703,9 @@ utf8_t *utf8ndup_ex(const utf8_t *src, size_t n,
   n = bytes;
 
   if (alloc_func_ptr) {
-    c = (char *)alloc_func_ptr(user_data, bytes + 1);
+    c = (utf8_t_ *)alloc_func_ptr(user_data, bytes + 1);
   } else {
-    c = (char *)malloc(bytes + 1);
+    c = (utf8_t_ *)malloc(bytes + 1);
   }
 
   if (utf8_null == c) {
@@ -720,9 +727,9 @@ utf8_t *utf8ndup_ex(const utf8_t *src, size_t n,
 }
 
 utf8_constexpr14 utf8_t *utf8rchr(const utf8_t *src, int chr) {
-  const char *s = (const char *)src;
-  const char *match = utf8_null;
-  char c[5] = {'\0', '\0', '\0', '\0', '\0'};
+  const utf8_t_ *s = (const utf8_t_ *)src;
+  const utf8_t_ *match = utf8_null;
+  utf8_t_ c[5] = {'\0', '\0', '\0', '\0', '\0'};
 
   if (0 == chr) {
     // being asked to return position of null terminating byte, so
@@ -734,25 +741,25 @@ utf8_constexpr14 utf8_t *utf8rchr(const utf8_t *src, int chr) {
   } else if (0 == ((int)0xffffff80 & chr)) {
     // 1-byte/7-bit ascii
     // (0b0xxxxxxx)
-    c[0] = (char)chr;
+    c[0] = (utf8_t_) chr;
   } else if (0 == ((int)0xfffff800 & chr)) {
     // 2-byte/11-bit utf8 code point
     // (0b110xxxxx 0b10xxxxxx)
-    c[0] = (char) (0xc0 | (char)(chr >> 6));
-    c[1] = (char) (0x80 | (char)(chr & 0x3f));
+    c[0] = (utf8_t_)  (0xc0 | (utf8_t_) (chr >> 6));
+    c[1] = (utf8_t_)  (0x80 | (utf8_t_) (chr & 0x3f));
   } else if (0 == ((int)0xffff0000 & chr)) {
     // 3-byte/16-bit utf8 code point
     // (0b1110xxxx 0b10xxxxxx 0b10xxxxxx)
-    c[0] = (char) (0xe0 | (char)(chr >> 12));
-    c[1] = (char) (0x80 | (char)((chr >> 6) & 0x3f));
-    c[2] = (char) (0x80 | (char)(chr & 0x3f));
+    c[0] = (utf8_t_)  (0xe0 | (utf8_t_) (chr >> 12));
+    c[1] = (utf8_t_)  (0x80 | (utf8_t_) ((chr >> 6) & 0x3f));
+    c[2] = (utf8_t_)  (0x80 | (utf8_t_) (chr & 0x3f));
   } else { // if (0 == ((int)0xffe00000 & chr)) {
     // 4-byte/21-bit utf8 code point
     // (0b11110xxx 0b10xxxxxx 0b10xxxxxx 0b10xxxxxx)
-    c[0] = (char) (0xf0 | (char)(chr >> 18));
-    c[1] = (char) (0x80 | (char)((chr >> 12) & 0x3f));
-    c[2] = (char) (0x80 | (char)((chr >> 6) & 0x3f));
-    c[3] = (char) (0x80 | (char)(chr & 0x3f));
+    c[0] = (utf8_t_)  (0xf0 | (utf8_t_) (chr >> 18));
+    c[1] = (utf8_t_)  (0x80 | (utf8_t_) ((chr >> 12) & 0x3f));
+    c[2] = (utf8_t_)  (0x80 | (utf8_t_) ((chr >> 6) & 0x3f));
+    c[3] = (utf8_t_)  (0x80 | (utf8_t_) (chr & 0x3f));
   }
 
   // we've created a 2 utf8 codepoint string in c that is
@@ -788,10 +795,10 @@ utf8_constexpr14 utf8_t *utf8rchr(const utf8_t *src, int chr) {
 }
 
 utf8_constexpr14 utf8_t *utf8pbrk(const utf8_t *str, const utf8_t *accept) {
-  const char *s = (const char *)str;
+  const utf8_t_ *s = (const utf8_t_ *)str;
 
   while ('\0' != *s) {
-    const char *a = (const char *)accept;
+    const utf8_t_ *a = (const utf8_t_ *)accept;
     size_t offset = 0;
 
     while ('\0' != *a) {
@@ -845,7 +852,7 @@ utf8_constexpr14 size_t utf8size_lazy(const utf8_t *str) {
 }
 
 utf8_constexpr14 size_t utf8nsize_lazy(const utf8_t *str, size_t n) {
-  const char *s = (const char *)str;
+  const utf8_t_ *s = (const utf8_t_ *)str;
   size_t size = 0;
   while (size < n && '\0' != s[size]) {
     size++;
@@ -854,11 +861,11 @@ utf8_constexpr14 size_t utf8nsize_lazy(const utf8_t *str, size_t n) {
 }
 
 utf8_constexpr14 size_t utf8spn(const utf8_t *src, const utf8_t *accept) {
-  const char *s = (const char *)src;
+  const utf8_t_ *s = (const utf8_t_ *)src;
   size_t chars = 0;
 
   while ('\0' != *s) {
-    const char *a = (const char *)accept;
+    const utf8_t_ *a = (const utf8_t_ *)accept;
     size_t offset = 0;
 
     while ('\0' != *a) {
@@ -908,18 +915,18 @@ utf8_constexpr14 size_t utf8spn(const utf8_t *src, const utf8_t *accept) {
 }
 
 utf8_constexpr14 utf8_t *utf8str(const utf8_t *haystack, const utf8_t *needle) {
-  const char *h = (const char *)haystack;
+  const utf8_t_ *h = (const utf8_t_ *)haystack;
   utf8_int32_t throwaway_codepoint = 0;
 
   // if needle has no utf8 codepoints before the null terminating
   // byte then return haystack
-  if ('\0' == *((const char *)needle)) {
+  if ('\0' == *((const utf8_t_ *)needle)) {
     return (utf8_t *)haystack;
   }
 
   while ('\0' != *h) {
-    const char *maybeMatch = h;
-    const char *n = (const char *)needle;
+    const utf8_t_ *maybeMatch = h;
+    const utf8_t_ *n = (const utf8_t_ *)needle;
 
     while (*h == *n && (*h != '\0' && *n != '\0')) {
       n++;
@@ -934,7 +941,7 @@ utf8_constexpr14 utf8_t *utf8str(const utf8_t *haystack, const utf8_t *needle) {
       // h could be in the middle of an unmatching utf8 codepoint,
       // so we need to march it on to the next character beginning
       // starting from the current character
-      h = (const char *)utf8codepoint(maybeMatch, &throwaway_codepoint);
+      h = (const utf8_t_ *)utf8codepoint(maybeMatch, &throwaway_codepoint);
     }
   }
 
@@ -947,7 +954,7 @@ utf8_constexpr14 utf8_t *utf8casestr(const utf8_t *haystack, const utf8_t *needl
 
   // if needle has no utf8 codepoints before the null terminating
   // byte then return haystack
-  if ('\0' == *((const char *)needle)) {
+  if ('\0' == *((const utf8_t_ *)needle)) {
     return (utf8_t *)haystack;
   }
 
@@ -994,8 +1001,8 @@ utf8_constexpr14 utf8_t *utf8valid(const utf8_t *str) {
 }
 
 utf8_constexpr14 utf8_t *utf8nvalid(const utf8_t *str, size_t n) {
-  const char *s = (const char *)str;
-  const char *t = s;
+  const utf8_t_ *s = (const utf8_t_ *)str;
+  const utf8_t_ *t = s;
   size_t consumed = 0, remained = 0;
 
   while ((void) (consumed = (size_t) (s-t)), consumed < n && '\0' != *s) {
@@ -1093,9 +1100,9 @@ utf8_constexpr14 utf8_t *utf8nvalid(const utf8_t *str, size_t n) {
 }
 
 int utf8makevalid(utf8_t *str, const utf8_int32_t replacement) {
-  char *read = (char *)str;
-  char *write = read;
-  const char r = (char)replacement;
+  utf8_t_ *read = (utf8_t_ *)str;
+  utf8_t_ *write = read;
+  const utf8_t_ r = (utf8_t_) replacement;
   utf8_int32_t codepoint = 0;
 
   if (replacement > 0x7f) {
@@ -1114,8 +1121,8 @@ int utf8makevalid(utf8_t *str, const utf8_int32_t replacement) {
       }
 
       // 4-byte utf8 code point (began with 0b11110xxx)
-      read = (char *)utf8codepoint(read, &codepoint);
-      write = (char *)utf8catcodepoint(write, codepoint, 4);
+      read = (utf8_t_ *)utf8codepoint(read, &codepoint);
+      write = (utf8_t_ *)utf8catcodepoint(write, codepoint, 4);
     } else if (0xe0 == (0xf0 & *read)) {
       // ensure each of the 2 following bytes in this 3-byte
       // utf8 codepoint began with 0b10xxxxxx
@@ -1126,8 +1133,8 @@ int utf8makevalid(utf8_t *str, const utf8_int32_t replacement) {
       }
 
       // 3-byte utf8 code point (began with 0b1110xxxx)
-      read = (char *)utf8codepoint(read, &codepoint);
-      write = (char *)utf8catcodepoint(write, codepoint, 3);
+      read = (utf8_t_ *)utf8codepoint(read, &codepoint);
+      write = (utf8_t_ *)utf8catcodepoint(write, codepoint, 3);
     } else if (0xc0 == (0xe0 & *read)) {
       // ensure the 1 following byte in this 2-byte
       // utf8 codepoint began with 0b10xxxxxx
@@ -1138,12 +1145,12 @@ int utf8makevalid(utf8_t *str, const utf8_int32_t replacement) {
       }
 
       // 2-byte utf8 code point (began with 0b110xxxxx)
-      read = (char *)utf8codepoint(read, &codepoint);
-      write = (char *)utf8catcodepoint(write, codepoint, 2);
+      read = (utf8_t_ *)utf8codepoint(read, &codepoint);
+      write = (utf8_t_ *)utf8catcodepoint(write, codepoint, 2);
     } else if (0x00 == (0x80 & *read)) {
       // 1-byte ascii (began with 0b0xxxxxxx)
-      read = (char *)utf8codepoint(read, &codepoint);
-      write = (char *)utf8catcodepoint(write, codepoint, 1);
+      read = (utf8_t_ *)utf8codepoint(read, &codepoint);
+      write = (utf8_t_ *)utf8catcodepoint(write, codepoint, 1);
     } else {
       // if we got here then we've got a dangling continuation (0b10xxxxxx)
       *write++ = r;
@@ -1159,7 +1166,7 @@ int utf8makevalid(utf8_t *str, const utf8_int32_t replacement) {
 
 utf8_constexpr14 utf8_t *utf8codepoint(const utf8_t *utf8_restrict str,
                                      utf8_int32_t *utf8_restrict out_codepoint) {
-  const char *s = (const char *)str;
+  const utf8_t_ *s = (const utf8_t_ *)str;
 
   if (0xf0 == (0xf8 & s[0])) {
     // 4 byte utf8 codepoint
@@ -1185,7 +1192,7 @@ utf8_constexpr14 utf8_t *utf8codepoint(const utf8_t *utf8_restrict str,
 }
 
 utf8_constexpr14 size_t utf8codepointcalcsize(const utf8_t *str) {
-  const char *s = (const char *)str;
+  const utf8_t_ *s = (const utf8_t_ *)str;
 
   if (0xf0 == (0xf8 & s[0])) {
     // 4 byte utf8 codepoint
@@ -1215,7 +1222,7 @@ utf8_constexpr14 size_t utf8codepointsize(utf8_int32_t chr) {
 }
 
 utf8_t *utf8catcodepoint(utf8_t *str, utf8_int32_t chr, size_t n) {
-  char *s = (char *)str;
+  utf8_t_ *s = (utf8_t_ *)str;
 
   if (0 == ((utf8_int32_t)0xffffff80 & chr)) {
     // 1-byte/7-bit ascii
@@ -1223,7 +1230,7 @@ utf8_t *utf8catcodepoint(utf8_t *str, utf8_int32_t chr, size_t n) {
     if (n < 1) {
       return utf8_null;
     }
-    s[0] = (char)chr;
+    s[0] = (utf8_t_) chr;
     s += 1;
   } else if (0 == ((utf8_int32_t)0xfffff800 & chr)) {
     // 2-byte/11-bit utf8 code point
@@ -1231,8 +1238,8 @@ utf8_t *utf8catcodepoint(utf8_t *str, utf8_int32_t chr, size_t n) {
     if (n < 2) {
       return utf8_null;
     }
-    s[0] = (char) (0xc0 | (char)((chr >> 6) & 0x1f));
-    s[1] = (char) (0x80 | (char)(chr & 0x3f));
+    s[0] = (utf8_t_)  (0xc0 | (utf8_t_) ((chr >> 6) & 0x1f));
+    s[1] = (utf8_t_)  (0x80 | (utf8_t_) (chr & 0x3f));
     s += 2;
   } else if (0 == ((utf8_int32_t)0xffff0000 & chr)) {
     // 3-byte/16-bit utf8 code point
@@ -1240,9 +1247,9 @@ utf8_t *utf8catcodepoint(utf8_t *str, utf8_int32_t chr, size_t n) {
     if (n < 3) {
       return utf8_null;
     }
-    s[0] = (char) (0xe0 | (char)((chr >> 12) & 0x0f));
-    s[1] = (char) (0x80 | (char)((chr >> 6) & 0x3f));
-    s[2] = (char) (0x80 | (char)(chr & 0x3f));
+    s[0] = (utf8_t_)  (0xe0 | (utf8_t_) ((chr >> 12) & 0x0f));
+    s[1] = (utf8_t_)  (0x80 | (utf8_t_) ((chr >> 6) & 0x3f));
+    s[2] = (utf8_t_)  (0x80 | (utf8_t_) (chr & 0x3f));
     s += 3;
   } else { // if (0 == ((int)0xffe00000 & chr)) {
     // 4-byte/21-bit utf8 code point
@@ -1250,10 +1257,10 @@ utf8_t *utf8catcodepoint(utf8_t *str, utf8_int32_t chr, size_t n) {
     if (n < 4) {
       return utf8_null;
     }
-    s[0] = (char) (0xf0 | (char)((chr >> 18) & 0x07));
-    s[1] = (char) (0x80 | (char)((chr >> 12) & 0x3f));
-    s[2] = (char) (0x80 | (char)((chr >> 6) & 0x3f));
-    s[3] = (char) (0x80 | (char)(chr & 0x3f));
+    s[0] = (utf8_t_)  (0xf0 | (utf8_t_) ((chr >> 18) & 0x07));
+    s[1] = (utf8_t_)  (0x80 | (utf8_t_) ((chr >> 12) & 0x3f));
+    s[2] = (utf8_t_)  (0x80 | (utf8_t_) ((chr >> 6) & 0x3f));
+    s[3] = (utf8_t_)  (0x80 | (utf8_t_) (chr & 0x3f));
     s += 4;
   }
 
@@ -1268,7 +1275,7 @@ void utf8lwr(utf8_t *utf8_restrict str) {
   utf8_t *p = utf8_null, *pn = utf8_null;
   utf8_int32_t cp = 0;
 
-  p = (char *)str;
+  p = (utf8_t_ *)str;
   pn = utf8codepoint(p, &cp);
 
   while (cp != 0) {
@@ -1288,7 +1295,7 @@ void utf8upr(utf8_t *utf8_restrict str) {
   utf8_t *p = utf8_null, *pn = utf8_null;
   utf8_int32_t cp = 0;
 
-  p = (char *)str;
+  p = (utf8_t_ *)str;
   pn = utf8codepoint(p, &cp);
 
   while (cp != 0) {
@@ -1638,7 +1645,7 @@ utf8_constexpr14 utf8_int32_t utf8uprcodepoint(utf8_int32_t cp) {
 
 utf8_constexpr14 utf8_t *utf8rcodepoint(const utf8_t *utf8_restrict str,
                      utf8_int32_t *utf8_restrict out_codepoint) {
-  const char *s = (const char *)str;
+  const utf8_t_ *s = (const utf8_t_ *)str;
 
   if (0xf0 == (0xf8 & s[0])) {
     // 4 byte utf8 codepoint


### PR DESCRIPTION
This feature required more changes than expected. I will understand if you prefer not to merge it

See the commit history for details, and please ask me anything if you need to