### PR TITLE
Fix utf8ncasecmp bug, not allowing for negative return. Add test case.

### DIFF
--- a/test/main.c
+++ b/test/main.c
@@ -1210,6 +1210,10 @@ UTEST(utf8ncasecmp, basic_ascii) {
 #endif
 }
 
+UTEST(utf8ncasecmp, latin_extended_a) {
+	ASSERT_EQ(96, utf8ncasecmp("Camón Romasan", "camu", 4));
+}
+
 UTEST(utf8codepoint, data) {
   utf8_int32_t codepoint;
   void *v;

--- a/utf8.h
+++ b/utf8.h
@@ -568,7 +568,7 @@ utf8_constexpr14_impl int utf8ncasecmp(const utf8_int8_t *src1,
       const utf8_int32_t c1 = (0xe0 & *s1);
       const utf8_int32_t c2 = (0xe0 & *s2);
 
-      if (c1 < c2) {
+      if (c1 != c2) {
         return c1 - c2;
       } else {
         return 0;
@@ -579,7 +579,7 @@ utf8_constexpr14_impl int utf8ncasecmp(const utf8_int8_t *src1,
       const utf8_int32_t c1 = (0xf0 & *s1);
       const utf8_int32_t c2 = (0xf0 & *s2);
 
-      if (c1 < c2) {
+      if (c1 != c2) {
         return c1 - c2;
       } else {
         return 0;
@@ -590,7 +590,7 @@ utf8_constexpr14_impl int utf8ncasecmp(const utf8_int8_t *src1,
       const utf8_int32_t c1 = (0xf8 & *s1);
       const utf8_int32_t c2 = (0xf8 & *s2);
 
-      if (c1 < c2) {
+      if (c1 != c2) {
         return c1 - c2;
       } else {
         return 0;


### PR DESCRIPTION
Hi @sheredom ,

`utf8ncasecmp("Camón Romasan", "camu", 4)` returns 0, which I believe is incorrect.

The proposed patch fixes this. I also added a test case for it.