### PR TITLE
Better compatibility with MSVC compiler

### DIFF
--- a/test/test.cpp
+++ b/test/test.cpp
@@ -35,7 +35,7 @@
 #endif
 #endif
 
-#if defined(utf8_cplusplus) && utf8_cplusplus >= 201402L
+#if defined(utf8_cplusplus) && utf8_cplusplus >= 201402L && (!defined(_MSC_VER) || (defined(_MSC_VER) && _MSC_VER >= 1910))
 constexpr void test() {
   constexpr utf8_int8_t in_str[20]{};
   constexpr utf8_int32_t in_chr{};

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -35,7 +35,7 @@
 #endif
 #endif
 
-#if defined(__cplusplus) && __cplusplus >= 201402L
+#if defined(utf8_cplusplus) && utf8_cplusplus >= 201402L
 constexpr void test() {
   constexpr utf8_int8_t in_str[20]{};
   constexpr utf8_int32_t in_chr{};

--- a/utf8.h
+++ b/utf8.h
@@ -43,6 +43,14 @@
 #pragma warning(disable : 4820)
 #endif
 
+#if defined(__cplusplus)
+#if defined(_MSC_VER)
+#define utf8_cplusplus _MSVC_LANG
+#else
+#define utf8_cplusplus __cplusplus
+#endif
+#endif
+
 #include <stddef.h>
 #include <stdlib.h>
 
@@ -67,7 +75,7 @@ typedef int32_t utf8_int32_t;
 #endif
 #endif
 
-#ifdef __cplusplus
+#ifdef utf8_cplusplus
 extern "C" {
 #endif
 
@@ -96,13 +104,13 @@ extern "C" {
 #error Non clang, non gcc, non MSVC, non tcc compiler found!
 #endif
 
-#ifdef __cplusplus
+#ifdef utf8_cplusplus
 #define utf8_null NULL
 #else
 #define utf8_null 0
 #endif
 
-#if (defined(__cplusplus) && __cplusplus >= 201402L)
+#if (defined(utf8_cplusplus) && utf8_cplusplus >= 201402L)
 #define utf8_constexpr14 constexpr
 #define utf8_constexpr14_impl constexpr
 #else
@@ -111,7 +119,7 @@ extern "C" {
 #define utf8_constexpr14_impl
 #endif
 
-#if defined(__cplusplus) && __cplusplus >= 202002L
+#if defined(utf8_cplusplus) && utf8_cplusplus >= 202002L
 using utf8_int8_t = char8_t; /* Introduced in C++20 */
 #else
 typedef char utf8_int8_t;
@@ -1693,7 +1701,7 @@ utf8rcodepoint(const utf8_int8_t *utf8_restrict str,
 #undef utf8_constexpr14
 #undef utf8_null
 
-#ifdef __cplusplus
+#ifdef utf8_cplusplus
 } /* extern "C" */
 #endif
 

--- a/utf8.h
+++ b/utf8.h
@@ -110,7 +110,7 @@ extern "C" {
 #define utf8_null 0
 #endif
 
-#if (defined(utf8_cplusplus) && utf8_cplusplus >= 201402L)
+#if defined(utf8_cplusplus) && utf8_cplusplus >= 201402L && (!defined(_MSC_VER) || (defined(_MSC_VER) && _MSC_VER >= 1910))
 #define utf8_constexpr14 constexpr
 #define utf8_constexpr14_impl constexpr
 #else


### PR DESCRIPTION
This commit removes the need to include `/Zc:__cplusplus` in Visual Studio projects, by replacing `__cplusplus` macro with `utf8_cplusplus`, which uses `_MSVC_LANG` to get the current C++ version. On other compilers `utf8_cplusplus` is defined as `__cplusplus`.