### PR TITLE
Add support for C++20 without char8_t

### DIFF
--- a/utf8.h
+++ b/utf8.h
@@ -119,7 +119,7 @@ extern "C" {
 #define utf8_constexpr14_impl
 #endif
 
-#if defined(utf8_cplusplus) && utf8_cplusplus >= 202002L
+#if defined(utf8_cplusplus) && utf8_cplusplus >= 202002L && defined(__cpp_char8_t)
 using utf8_int8_t = char8_t; /* Introduced in C++20 */
 #else
 typedef char utf8_int8_t;


### PR DESCRIPTION
This PR adds support for compilation in C++20 without having `char8_t` enabled.

`char8_t` can be manually disabled on MSVC using `/Zc:char8_t-` and on GCC/clang with `-fno-char8_t`